### PR TITLE
xvbf fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,6 @@ pytest-timeout
 pytest-xdist
 pytest-xvfb # Prevents the gym popups from displaying during tests.
 # Required for the RL methods
+# TODO: Move this to an 'extras' in setup.py?
 stable-baselines3
+pyvirtualdisplay

--- a/sequoia/common/gym_wrappers/pixel_observation.py
+++ b/sequoia/common/gym_wrappers/pixel_observation.py
@@ -24,9 +24,6 @@ class PixelObservationWrapper(PixelObservationWrapper_):
         if isinstance(env, str):
             env = gym.make(env)
         env.reset()
-        from pyvirtualdisplay import Display
-        display = Display(visible=0, size=(1366, 768))
-        display.start()
         super().__init__(env)
         self.observation_space = self.observation_space["pixels"]
         from gym.envs.classic_control.rendering import Viewer


### PR DESCRIPTION
Remove the need of calling with xvbf-run.

Introduces a dependency on `pyvirtualdisplay`. I have put it in the constructor to avoid import fails.

Works on a remote unix workstation.

Provably needs some refining.