### PR TITLE
Remove hard dependency on atari_py, fix small bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Requires python >= 3.7
 	$ cd Sequoia
 	```
 
-2. Optional: Create the conda environment (only need to do this once):
+2. Optional: Create the conda environment (only once):
 
 	```console
 	$ conda create -f environment.yaml

--- a/examples/advanced/hat_demo.py
+++ b/examples/advanced/hat_demo.py
@@ -268,8 +268,8 @@ class HatMethod(Method, target_setting=TaskIncrementalSetting):
         self.model.current_task = task_id
 
     @classmethod
-    def add_argparse_args(cls, parser: ArgumentParser, dest: str = None) -> None:
-        parser.add_arguments(cls.HParams, dest="hparams")
+    def add_argparse_args(cls, parser: ArgumentParser, dest: str = "") -> None:
+        parser.add_arguments(cls.HParams, dest=f"{dest}.hparams" if dest else "hparams")
         # You can also add arguments as usual:
         # parser.add_argument("--foo", default=123)
 

--- a/examples/advanced/hat_demo.py
+++ b/examples/advanced/hat_demo.py
@@ -269,13 +269,12 @@ class HatMethod(Method, target_setting=TaskIncrementalSetting):
 
     @classmethod
     def add_argparse_args(cls, parser: ArgumentParser, dest: str = "") -> None:
-        parser.add_arguments(cls.HParams, dest=f"{dest}.hparams" if dest else "hparams")
+        parser.add_arguments(cls.HParams, dest="hparams")
         # You can also add arguments as usual:
         # parser.add_argument("--foo", default=123)
 
     @classmethod
     def from_argparse_args(cls, args, dest: str = "") -> "HatMethod":
-        args = getattr(args, dest) if dest else args
         hparams: HatMethod.HParams = args.hparams
         # foo: int = args.foo
         method = cls(hparams=hparams)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 timeout = 30
 testpaths =
-    sequoia/experiment_test.py
+    sequoia/experiments
     sequoia/common
     sequoia/settings
     sequoia/methods

--- a/sequoia/common/gym_wrappers/batch_env/async_vector_env_test.py
+++ b/sequoia/common/gym_wrappers/batch_env/async_vector_env_test.py
@@ -8,7 +8,7 @@ from sequoia.common.gym_wrappers import MultiTaskEnvironment
 from gym import Env, Wrapper
 from gym.envs.classic_control import CartPoleEnv
 from gym import spaces
-
+from sequoia.conftest import param_requires_atari_py
 from .async_vector_env import AsyncVectorEnv
 
 @pytest.fixture()
@@ -19,7 +19,7 @@ def allow_remote_getattr(monkeypatch):
 
 @pytest.mark.parametrize("env_name, expected_obs_shape", [
     ("CartPole-v0", (4,)),    
-    ("Breakout-v0", (210, 160, 3)),    
+    param_requires_atari_py("Breakout-v0", (210, 160, 3)),    
 ])
 @pytest.mark.parametrize("batch_size", [1, 2, 5])
 def test_spaces(batch_size: int, env_name: str, expected_obs_shape: Tuple[int, ...]):

--- a/sequoia/common/gym_wrappers/batch_env/batched_vector_env_test.py
+++ b/sequoia/common/gym_wrappers/batch_env/batched_vector_env_test.py
@@ -10,11 +10,12 @@ import pytest
 
 from .batched_vector_env import BatchedVectorEnv
 
-from sequoia.conftest import DummyEnvironment, slow_param, slow
+from sequoia.conftest import DummyEnvironment, slow_param, slow, atari_py_required, param_requires_atari_py
 
 from sequoia.common.gym_wrappers.multi_task_environment import MultiTaskEnvironment
 
 
+@atari_py_required
 @pytest.mark.parametrize("batch_size", [1, 5, slow_param(11), slow_param(24)])
 @pytest.mark.parametrize("n_workers", [1, 3, None])
 def test_space_with_tuple_observations(batch_size: int, n_workers: Optional[int]):
@@ -181,7 +182,7 @@ def test_render_human():
             env.viewer.window
 
 
-@pytest.mark.parametrize("env_name", ["CartPole-v0", "Pendulum-v0", "Breakout-v0"])
+@pytest.mark.parametrize("env_name", ["CartPole-v0", "Pendulum-v0", param_requires_atari_py("Breakout-v0")])
 def test_with_pixelobservationwrapper_before_batch(env_name: str):
     """ Test out what happens if we put the PixelObservationWrapper before the 
     batching, i.e. in each of the environments.

--- a/sequoia/common/gym_wrappers/convert_tensors_test.py
+++ b/sequoia/common/gym_wrappers/convert_tensors_test.py
@@ -40,7 +40,7 @@ from sequoia.conftest import skipif_param
     ],
 )
 def test_convert_tensors_wrapper(device: Union[str, torch.device]):
-    env_name = "Breakout-v0"
+    env_name = "CartPole-v0"
     env = gym.make(env_name)
     env = ConvertToFromTensors(env, device=device)
     obs = env.reset()

--- a/sequoia/common/gym_wrappers/env_dataset_test.py
+++ b/sequoia/common/gym_wrappers/env_dataset_test.py
@@ -8,7 +8,7 @@ from gym import spaces
 from gym.spaces import Discrete
 
 from sequoia.common.transforms import Transforms
-from sequoia.conftest import DummyEnvironment
+from sequoia.conftest import DummyEnvironment, atari_py_required
 from sequoia.settings.active.continual.make_env import make_batched_env
 
 from .env_dataset import EnvDataset
@@ -191,7 +191,7 @@ class DummyWrapper(TransformObservation):
         print(f"Result shape: {result.shape}, max: {result.max()}")
         return result
 
-
+@atari_py_required
 def test_observation_wrapper_applies_to_yielded_objects():
     """ Test that when an TransformObservation wrapper (or any wrapper that
     changes the Observations) is applied on the env, the observations that are
@@ -245,7 +245,7 @@ def test_observation_wrapper_applies_to_yielded_objects():
 
     env.close()
 
-
+@atari_py_required
 def test_iteration_with_more_than_one_wrapper():
     """ Same as above, but with more than one wrapper applied on top of the
     EnvDataset.

--- a/sequoia/common/gym_wrappers/multi_task_environment_test.py
+++ b/sequoia/common/gym_wrappers/multi_task_environment_test.py
@@ -10,7 +10,7 @@ from gym.wrappers import TimeLimit
 
 from sequoia.common.gym_wrappers import MultiTaskEnvironment
 from sequoia.common.spaces.named_tuple import NamedTuple, NamedTupleSpace
-from sequoia.conftest import monsterkong_required, param_requires_monsterkong
+from sequoia.conftest import monsterkong_required, param_requires_monsterkong, atari_py_required
 from sequoia.settings import RLSetting
 from sequoia.utils.utils import dict_union
 
@@ -285,7 +285,7 @@ def test_starting_step_and_max_step():
     env.close()
 
 
-
+@atari_py_required
 def test_task_id_is_added_even_when_no_known_task_schedule():
     """ Test that even when the env is unknown or there are no task params, the
     task_id is still added correctly and is zero at all times.

--- a/sequoia/common/gym_wrappers/utils.py
+++ b/sequoia/common/gym_wrappers/utils.py
@@ -31,8 +31,11 @@ def is_atari_env(env: Union[str, gym.Env]) -> bool:
     # way to do this.
     if isinstance(env, str) and env.startswith("Breakout"):
         return True
-    if isinstance(env, gym.Env) and isinstance(env.unwrapped, AtariEnv):
-        return True
+    try:
+        from gym.envs.atari import AtariEnv
+        return isinstance(env, gym.Env) and isinstance(env.unwrapped, AtariEnv)
+    except gym.error.DependencyNotInstalled:
+        return False
     return False
 
 logger = get_logger(__file__)

--- a/sequoia/common/gym_wrappers/utils_test.py
+++ b/sequoia/common/gym_wrappers/utils_test.py
@@ -1,10 +1,10 @@
 import gym
-from gym.wrappers import FilterObservation, ClipAction, AtariPreprocessing
-from gym.wrappers.pixel_observation import PixelObservationWrapper
 import pytest
+from gym.wrappers import AtariPreprocessing, ClipAction, FilterObservation
+from gym.wrappers.pixel_observation import PixelObservationWrapper
+from sequoia.conftest import param_requires_atari_py
 
 from .pixel_observation import PixelObservationWrapper
-
 from .utils import has_wrapper
 
 
@@ -13,7 +13,7 @@ from .utils import has_wrapper
     (lambda: PixelObservationWrapper(gym.make("CartPole-v0")), ClipAction, False),
     (lambda: PixelObservationWrapper(gym.make("CartPole-v0")), PixelObservationWrapper, True),
     (lambda: PixelObservationWrapper(gym.make("CartPole-v0")), PixelObservationWrapper, True),
-    # (AtariPreprocessing(gym.make("Breakout-v0")), ClipAction, True),
+    # param_requires_atari_py(AtariPreprocessing(gym.make("Breakout-v0")), ClipAction, True),
 ])
 def test_has_wrapper(env, wrapper_type, result):
     assert has_wrapper(env(), wrapper_type) == result

--- a/sequoia/conftest.py
+++ b/sequoia/conftest.py
@@ -264,3 +264,23 @@ def param_requires_monsterkong(*args):
         *args,
         reason="monsterkong is required for this parameter.",
     )
+
+try:
+    with redirect_stdout(StringIO()):
+        from gym.envs.atari import AtariEnv
+except gym.error.DependencyNotInstalled:
+    atari_py_installed = False
+else:
+    atari_py_installed = True
+
+
+atari_py_required = pytest.mark.skipif(
+    not atari_py_installed, reason="atari_py is required for this test."
+)
+
+def param_requires_atari_py(*args):
+    return skipif_param(
+        not atari_py_installed,
+        *args,
+        reason="atari_py is required for this parameter.",
+    )

--- a/sequoia/methods/stable_baselines3_methods/ppo.py
+++ b/sequoia/methods/stable_baselines3_methods/ppo.py
@@ -8,7 +8,6 @@ import gym
 import torch
 from gym import spaces
 from simple_parsing import mutable_field
-from stable_baselines3.common.type_aliases import Schedule
 from stable_baselines3.ppo import PPO
 
 from sequoia.common.hparams import categorical, log_uniform, uniform
@@ -40,7 +39,7 @@ class PPOModel(PPO):
 
         # The learning rate, it can be a function of the current progress remaining
         # (from 1 to 0)
-        learning_rate: Union[float, Schedule] = log_uniform(1e-6, 1e-2, default=3e-4)
+        learning_rate: float = log_uniform(1e-6, 1e-2, default=3e-4)
 
         # The number of steps to run for each environment per update (i.e. batch size
         # is n_steps * n_env where n_env is number of environment copies running in
@@ -62,13 +61,13 @@ class PPOModel(PPO):
 
         # Clipping parameter, it can be a function of the current progress remaining
         # (from 1 to 0).
-        clip_range: Union[float, Schedule] = uniform(0.05, 0.4, default=0.2)
+        clip_range: float = uniform(0.05, 0.4, default=0.2)
 
         # Clipping parameter for the value function, it can be a function of the current
         # progress remaining (from 1 to 0). This is a parameter specific to the OpenAI
         # implementation. If None is passed (default), no clipping will be done on the
         # value function. IMPORTANT: this clipping depends on the reward scaling.
-        clip_range_vf: Union[None, float, Schedule] = None
+        clip_range_vf: Optional[float] = None
 
         # Entropy coefficient for the loss calculation
         ent_coef: float = uniform(0., 1., default=0.0)

--- a/sequoia/settings/active/continual/continual_rl_setting.py
+++ b/sequoia/settings/active/continual/continual_rl_setting.py
@@ -12,7 +12,7 @@ from typing import (Callable, ClassVar, Dict, List, Optional, Sequence, Type,
 import gym
 import numpy as np
 from gym import spaces
-from gym.envs.atari import AtariEnv
+# from gym.envs.atari import AtariEnv
 from gym.envs.classic_control import CartPoleEnv
 from gym.utils import colorize
 from gym.wrappers import AtariPreprocessing, TimeLimit
@@ -79,11 +79,11 @@ task_params: Dict[Union[Type[gym.Env], str], List[str]] = {
     # TODO: Add more of the classic control envs here.
     # TODO: Need to get the attributes to modify in each environment type and
     # add them here.
-    AtariEnv: [
-        # TODO: Maybe have something like the difficulty as the CL 'task' ?
-        # difficulties = temp_env.ale.getAvailableDifficulties()
-        # "game_difficulty",
-    ],      
+    # AtariEnv: [
+    #     # TODO: Maybe have something like the difficulty as the CL 'task' ?
+    #     # difficulties = temp_env.ale.getAvailableDifficulties()
+    #     # "game_difficulty",
+    # ],      
 }
 
 # Type alias for the Environment returned by `train/val/test_dataloader`.

--- a/sequoia/settings/active/continual/continual_rl_setting.py
+++ b/sequoia/settings/active/continual/continual_rl_setting.py
@@ -12,7 +12,6 @@ from typing import (Callable, ClassVar, Dict, List, Optional, Sequence, Type,
 import gym
 import numpy as np
 from gym import spaces
-# from gym.envs.atari import AtariEnv
 from gym.envs.classic_control import CartPoleEnv
 from gym.utils import colorize
 from gym.wrappers import AtariPreprocessing, TimeLimit
@@ -133,6 +132,8 @@ class ContinualRLSetting(ActiveSetting, IncrementalSetting):
         "breakout": "Breakout-v0",
         # "duckietown": "Duckietown-straight_road-v0"
     }
+    # TODO: Add breakout to 'available_datasets' only when atari_py is installed. 
+    
     # Which environment (a.k.a. "dataset") to learn on.
     # The dataset could be either a string (env id or a key from the
     # available_datasets dict), a gym.Env, or a callable that returns a single environment.

--- a/sequoia/settings/active/continual/continual_rl_setting_test.py
+++ b/sequoia/settings/active/continual/continual_rl_setting_test.py
@@ -9,7 +9,7 @@ from gym import spaces
 from sequoia.common.config import Config
 from sequoia.common.spaces import Sparse
 from sequoia.common.transforms import ChannelsFirstIfNeeded, ToTensor, Transforms
-from sequoia.conftest import xfail_param
+from sequoia.conftest import xfail_param, param_requires_atari_py
 from sequoia.utils.utils import take
 
 from .continual_rl_setting import ContinualRLSetting
@@ -40,8 +40,8 @@ def test_task_schedule_is_used():
 @pytest.mark.parametrize(
     "dataset, expected_obs_shape", [
         ("CartPole-v0", (3, 400, 600)),
-        # ("Breakout-v0", (3, 210, 160)), 
-        ("Breakout-v0", (3, 84, 84)), # Since the AtariWrapper gets added by default
+        # param_requires_atari_py("Breakout-v0", (3, 210, 160)), 
+        param_requires_atari_py("Breakout-v0", (3, 84, 84)), # Since the AtariWrapper gets added by default
         # ("duckietown", (120, 160, 3)),
     ],
 )

--- a/sequoia/settings/active/continual/gym_dataloader_test.py
+++ b/sequoia/settings/active/continual/gym_dataloader_test.py
@@ -6,29 +6,28 @@ import gym
 import numpy as np
 import pytest
 import torch
-from sequoia.conftest import DummyEnvironment, xfail
 from gym import spaces
 from gym.envs.classic_control import CartPoleEnv, PendulumEnv
 from gym.vector.utils import batch_space
 from torch import Tensor
 
 from sequoia.common.gym_wrappers import (AsyncVectorEnv, ConvertToFromTensors,
-                                 EnvDataset, PixelObservationWrapper,
-                                 TransformObservation)
+                                         EnvDataset, PixelObservationWrapper,
+                                         TransformObservation)
 from sequoia.common.transforms import ChannelsFirstIfNeeded, Transforms
-from .gym_dataloader import GymDataLoader
-from .make_env import make_batched_env
+from sequoia.conftest import DummyEnvironment, param_requires_atari_py, xfail
 from sequoia.utils import take
 from sequoia.utils.logging_utils import get_logger
 
-from sequoia.common.gym_wrappers import EnvDataset
+from .gym_dataloader import GymDataLoader
+from .make_env import make_batched_env
 
 logger = get_logger(__file__)
 
 
 
 @pytest.mark.parametrize("batch_size", [1, 2, 5])
-@pytest.mark.parametrize("env_name", ["CartPole-v0", "Breakout-v0"])
+@pytest.mark.parametrize("env_name", ["CartPole-v0", param_requires_atari_py("Breakout-v0")])
 def test_spaces(env_name: str, batch_size: int):
     dataset = EnvDataset(make_batched_env(env_name, batch_size=batch_size))
     
@@ -58,7 +57,7 @@ def test_spaces(env_name: str, batch_size: int):
 
 
 @pytest.mark.parametrize("batch_size", [None, 1, 2, 5])
-@pytest.mark.parametrize("env_name", ["CartPole-v0", "Breakout-v0"])
+@pytest.mark.parametrize("env_name", ["CartPole-v0", param_requires_atari_py("Breakout-v0")])
 def test_max_steps_is_respected(env_name: str, batch_size: int):
     max_steps = 5
     env_name = "CartPole-v0"
@@ -77,7 +76,7 @@ def test_max_steps_is_respected(env_name: str, batch_size: int):
 
 
 @pytest.mark.parametrize("batch_size", [None, 1, 2, 5])
-@pytest.mark.parametrize("env_name", ["CartPole-v0", "Breakout-v0"])
+@pytest.mark.parametrize("env_name", ["CartPole-v0", param_requires_atari_py("Breakout-v0")])
 def test_multiple_epochs_works(env_name: str, batch_size: int):
     
     epochs = 3
@@ -114,14 +113,9 @@ def test_multiple_epochs_works(env_name: str, batch_size: int):
         assert len(all_rewards) == epochs * max_steps_per_episode * batch_size
 
 
-
-
 @pytest.mark.parametrize("batch_size", [1, 2, 5])
-@pytest.mark.parametrize("env_name", ["Breakout-v0"])
+@pytest.mark.parametrize("env_name", [param_requires_atari_py("Breakout-v0")])
 def test_reward_isnt_always_one(env_name: str, batch_size: int):
-    # TODO: BUG: The CartPoleEnv always has a reward of 1.
-    
-    from gym.envs.atari import AtariEnv
     epochs = 3
     max_steps_per_episode = 100
     

--- a/sequoia/settings/active/continual/incremental/incremental_rl_setting_test.py
+++ b/sequoia/settings/active/continual/incremental/incremental_rl_setting_test.py
@@ -9,7 +9,7 @@ from sequoia.common.config import Config
 from sequoia.common.spaces import Image, Sparse
 from sequoia.common.transforms import (ChannelsFirstIfNeeded, ToTensor,
                                        Transforms)
-from sequoia.conftest import xfail_param, monsterkong_required
+from sequoia.conftest import xfail_param, monsterkong_required, param_requires_atari_py
 from sequoia.settings import Method
 from sequoia.settings.assumptions.incremental import TestEnvironment
 from sequoia.utils.utils import take
@@ -21,8 +21,8 @@ from .incremental_rl_setting import IncrementalRLSetting
 @pytest.mark.parametrize(
     "dataset, expected_obs_shape", [
         ("CartPole-v0", (3, 400, 600)),
-        # ("Breakout-v0", (3, 210, 160)),
-        ("Breakout-v0", (3, 84, 84)), # Since the Atari Preprocessing is added by default.
+        # param_requires_atari_py("Breakout-v0", (3, 210, 160)),
+        param_requires_atari_py("Breakout-v0", (3, 84, 84)), # Since the Atari Preprocessing is added by default.
         # ("duckietown", (120, 160, 3)),
     ],
 )


### PR DESCRIPTION
The atary_py package was a core dependency, and in order to install it, you need to have `cmake` installed on your machine!
(This btw @optimass is the reason why it was crashing on install on the ElementAI cluster!)

(Really) Fixes #103 

