### PR TITLE
Add "Multi-Task" Supervised Learning Setting

### DIFF
--- a/sequoia/common/gym_wrappers/__init__.py
+++ b/sequoia/common/gym_wrappers/__init__.py
@@ -2,7 +2,7 @@
 from .add_done import AddDoneToObservation
 from .add_info import AddInfoToObservation
 from .pixel_observation import PixelObservationWrapper
-from .utils import has_wrapper, IterableWrapper
+from .utils import has_wrapper, IterableWrapper, RenderEnvWrapper
 from .multi_task_environment import MultiTaskEnvironment
 from .smooth_environment import SmoothTransitions
 from .step_callback_wrapper import StepCallbackWrapper, StepCallback, PeriodicCallback

--- a/sequoia/common/gym_wrappers/convert_tensors.py
+++ b/sequoia/common/gym_wrappers/convert_tensors.py
@@ -67,8 +67,8 @@ def supports_tensors(space: S) -> bool:
 def has_tensor_support(space: S) -> bool:
     return supports_tensors(space)
 
-def _mark_supports_tensors(space: S) -> bool:
-    return setattr(space, "__supports_tensors", True)
+def _mark_supports_tensors(space: S) -> None:
+    setattr(space, "__supports_tensors", True)
 
 @singledispatch
 def add_tensor_support(space: S, device: torch.device = None) -> S:

--- a/sequoia/common/gym_wrappers/utils.py
+++ b/sequoia/common/gym_wrappers/utils.py
@@ -214,6 +214,14 @@ class IterableWrapper(gym.Wrapper, IterableDataset, ABC):
             object.__setattr__(self, attr, value)
 
 
+class RenderEnvWrapper(IterableWrapper):
+    """ Simple Wrapper that renders the env at each step. """
+
+    def step(self, action):
+        self.env.render("human")
+        return self.env.step(action)
+
+
 @singledispatch
 def reshape_space(space: gym.Space, new_shape: Tuple[int, ...]) -> gym.Space:
     """ Returns a new space based on 'space', but with a new shape.

--- a/sequoia/methods/baseline_method.py
+++ b/sequoia/methods/baseline_method.py
@@ -19,6 +19,7 @@ import wandb
 from pytorch_lightning import Callback, Trainer
 from simple_parsing import mutable_field
 
+from sequoia.common.gym_wrappers import RenderEnvWrapper
 from sequoia.common import Config, TrainerConfig
 from sequoia.common.config import WandbLoggerConfig
 from sequoia.settings import ActiveSetting, PassiveSetting
@@ -35,15 +36,6 @@ from sequoia.methods import register_method
 from .models import BaselineModel, ForwardPass
 
 logger = get_logger(__file__)
-from sequoia.common.gym_wrappers import IterableWrapper
-
-
-class RenderEnvWrapper(IterableWrapper):
-    """ Simple Wrapper that renders the env at each step. """
-
-    def step(self, action):
-        self.env.render("human")
-        return self.env.step(action)
 
 
 @register_method

--- a/sequoia/settings.puml
+++ b/sequoia/settings.puml
@@ -38,8 +38,12 @@ package settings {
     }
     
     package assumptions as settings.assumptions {
+        package continual as settings.assumptions.continual {
+            abstract class ContinualSetting extends Setting {
+            }
+        }
         package incremental as settings.assumptions.incremental {
-            abstract class IncrementalSetting extends Setting {
+            abstract class IncrementalSetting extends ContinualSetting {
                 + nb_tasks: int
                 + task_labels_at_train_time: bool
                 + task_labels_at_test_time: bool
@@ -63,6 +67,17 @@ package settings {
 
             }
         }
+        ' TODO: Need to rename `TaskIncrementalSetting` below to something like
+        ' `TaskIncrementalSL`
+        ' package task_incremental as settings.assumptions.task_incremental {
+        '     abstract class TaskIncrementalSetting extends IncrementalSetting {
+        '     }
+        ' }
+
+        ' package iid as settings.assumptions.iid {
+        '     abstract class IIDSetting extends TaskIncrementalSetting {
+        '     }
+        ' }
     }
 
     package passive as settings.passive {
@@ -84,25 +99,36 @@ package settings {
                 + task_labels_at_test_time: bool = False
                 + transforms: List[Transforms]
                 + class_order: Optional[List[int]] = None
+                + relabel: bool = False
             }
 
             class ClassIncrementalResults implements IncrementalResults {}
+            package domain_incremental as settings.passive.cl.domain_incremental {
+                class DomainIncrementalSetting extends ClassIncrementalSetting {
+                    + relabel: bool = True
+                }
+
+                 
+                
+            }
 
             package task_incremental as settings.passive.cl.task_incremental {
                 class TaskIncrementalSetting extends ClassIncrementalSetting {
                     {field} + task_labels_at_train_time: bool = True (constant)
                     {field} + task_labels_at_test_time: bool = True (constant)
                 }
-                class TaskIncrementalResults extends ClassIncrementalResults{}
-                
-                package iid as settings.passive.cl.task_incremental.iid {
-                    class IIDSetting extends TaskIncrementalSetting {
-                        {field} + nb_tasks: int = 1 (constant)
+                ' class TaskIncrementalResults extends ClassIncrementalResults{}
+               
+                package multi_task as settings.passive.cl.task_incremental.multi_task {
+                    class MultiTaskSetting extends TaskIncrementalSetting {
                     }
-                    class IIDResults extends TaskIncrementalResults{}
-
                 }
-            
+            }
+            package iid as settings.passive.cl.iid {
+                class IIDSetting extends TaskIncrementalSetting, DomainIncrementalSetting {
+                    {field} + nb_tasks: int = 1 (constant)
+                }
+                class IIDResults extends ClassIncrementalResults{}
             }
         }
     }

--- a/sequoia/settings/__init__.py
+++ b/sequoia/settings/__init__.py
@@ -18,6 +18,7 @@ all_settings: List[Type[Setting]] = [
     DomainIncrementalSetting,
     TaskIncrementalSetting,
     IIDSetting,
+    MultiTaskSetting,
     ContinualRLSetting,
     IncrementalRLSetting,
     TaskIncrementalRLSetting,

--- a/sequoia/settings/assumptions/continual.py
+++ b/sequoia/settings/assumptions/continual.py
@@ -1,7 +1,10 @@
 from sequoia.settings.base import Setting
 from sequoia.utils.utils import flag
+from sequoia.utils import get_logger
 
 from dataclasses import dataclass
+
+logger = get_logger(__file__)
 
 @dataclass
 class ContinualSetting(Setting):
@@ -13,3 +16,7 @@ class ContinualSetting(Setting):
     # Wether we have sudden changes in the environments, or if the transition
     # are "smooth".
     smooth_task_boundaries: bool = flag(True)
+
+    # TODO: Move everything necessary to get ContinualRLSetting to work out of
+    # Incremental and into this here. Makes no sense that ContinualRLSetting inherits
+    # from Incremental, rather than this!

--- a/sequoia/settings/assumptions/incremental.py
+++ b/sequoia/settings/assumptions/incremental.py
@@ -67,7 +67,12 @@ class IncrementalSetting(ContinualSetting):
         Adds the 'task labels' to the base Observation.
         """
         task_labels: Union[Optional[Tensor], Sequence[Optional[Tensor]]] = None
-
+    
+    # TODO: Actually add the 'smooth' task boundary case.
+    # Wether we have clear boundaries between tasks, or if the transition is
+    # smooth.
+    smooth_task_boundaries: bool = constant(False) # constant for now.
+    
     # Wether task labels are available at train time.
     # NOTE: Forced to True at the moment.
     task_labels_at_train_time: bool = flag(default=True)
@@ -83,10 +88,7 @@ class IncrementalSetting(ContinualSetting):
     # training. Only used when `smooth_task_boundaries` is False.
     known_task_boundaries_at_test_time: bool = constant(True)
 
-    # TODO: Actually add the 'smooth' task boundary case.
-    # Wether we have clear boundaries between tasks, or if the transition is
-    # smooth.
-    smooth_task_boundaries: bool = constant(False) # constant for now.
+  
     # The number of tasks. By default 0, which means that it will be set
     # depending on other fields in __post_init__, or eventually be just 1. 
     nb_tasks: int = field(0, alias=["n_tasks", "num_tasks"])
@@ -108,6 +110,9 @@ class IncrementalSetting(ContinualSetting):
         TODO: Do we want to return None if the task labels aren't currently
         available? (at either Train or Test time?) Or if we 'detect' if
         this is being called from the method?
+        
+        TODO: This property doesn't really make sense in the Multi-Task SL or RL
+        settings.
         """
         return self._current_task_id
 

--- a/sequoia/settings/base/setting.py
+++ b/sequoia/settings/base/setting.py
@@ -190,6 +190,11 @@ class Setting(SettingABC,
         # Setting. Might want to change this a bit.
         self.config: Config = None
 
+        self.train_env: Environment = None  # type: ignore
+        self.val_env: Environment = None  # type: ignore
+        self.test_env: Environment = None  # type: ignore
+    
+
     @abstractmethod
     def apply(self, method: Method, config: Config = None) -> "Setting.Results":
         # NOTE: The actual train/test loop should be defined in a more specific

--- a/sequoia/settings/passive/cl/class_incremental_setting.py
+++ b/sequoia/settings/passive/cl/class_incremental_setting.py
@@ -786,6 +786,14 @@ class ClassIncrementalTestEnvironment(TestEnvironment):
     def __init__(self, env: gym.Env, *args, **kwargs):
         super().__init__(env, *args, **kwargs)
         self._steps = 0
+        # TODO: Maybe rework this so we don't depend on the test phase being one task at
+        # a time, instead store the test metrics in the task corresponding to the
+        # task_label in the observations.
+        # BUG: The problem is, right now we're depending on being passed the
+        # 'task schedule', which we then use to get the task ids. This
+        # is actually pretty bad, because if the class ordering was changed between
+        # training and testing, then, this wouldn't actually report the correct results! 
+
         self.task_steps = sorted(self.env.task_schedule.keys())
         self.metrics: List[ClassificationMetrics] = [[] for step in self.task_steps]
         self._reset = False

--- a/sequoia/settings/passive/cl/class_incremental_setting.py
+++ b/sequoia/settings/passive/cl/class_incremental_setting.py
@@ -26,8 +26,8 @@ from abc import abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import (Callable, ClassVar, Dict, List, Optional, Sequence, Tuple,
-                    Type, Union)
+from typing import (Any, Callable, ClassVar, Dict, List, Optional, Sequence,
+                    Tuple, Type, Union)
 
 import gym
 import matplotlib.pyplot as plt
@@ -566,7 +566,8 @@ class ClassIncrementalSetting(PassiveSetting, IncrementalSetting):
         # 'split_batch_fn' at train and test time, or by using this wrapper
         # which is also used in the RL side of the tree:
         # TODO: Maybe remove/simplify the 'split_batch_function'.
-        from sequoia.settings.active.continual.wrappers import HideTaskLabelsWrapper
+        from sequoia.settings.active.continual.wrappers import \
+            HideTaskLabelsWrapper
         if not self.task_labels_at_test_time:
             env = HideTaskLabelsWrapper(env)
 

--- a/sequoia/settings/passive/cl/task_incremental/__init__.py
+++ b/sequoia/settings/passive/cl/task_incremental/__init__.py
@@ -10,3 +10,4 @@ from .. import ClassIncrementalResults as TaskIncrementalResults
 # 2. Import what we overwrite/customize
 from .task_incremental_setting import TaskIncrementalSetting
 from .iid import *
+from .multi_task import *

--- a/sequoia/settings/passive/cl/task_incremental/multi_task/__init__.py
+++ b/sequoia/settings/passive/cl/task_incremental/multi_task/__init__.py
@@ -1,0 +1,1 @@
+from .multi_task_setting import MultiTaskSetting

--- a/sequoia/settings/passive/cl/task_incremental/multi_task/multi_task_setting.py
+++ b/sequoia/settings/passive/cl/task_incremental/multi_task/multi_task_setting.py
@@ -1,0 +1,327 @@
+from dataclasses import dataclass
+from typing import Callable, ClassVar, Dict, List, Optional, Tuple, Type, TypeVar, Union
+
+from simple_parsing import list_field
+from torch.utils.data import ConcatDataset, DataLoader, Dataset
+
+from sequoia.common.gym_wrappers import RenderEnvWrapper, TransformObservation
+from sequoia.settings.base import Method
+from sequoia.settings.passive.passive_environment import PassiveEnvironment
+from sequoia.utils import get_logger
+from sequoia.utils.utils import constant
+from sequoia.settings.passive.cl.class_incremental_setting import ClassIncrementalTestEnvironment
+from sequoia.settings.assumptions.incremental import TestEnvironment
+
+from ..task_incremental_setting import TaskIncrementalSetting
+
+logger = get_logger(__file__)
+
+
+@dataclass
+class MultiTaskSetting(TaskIncrementalSetting):
+    """IID version of the Task-Incremental Setting, where the data is shuffled.
+    
+    Can be used to estimate the upper bound performance of Task-Incremental CL Methods.
+    """
+
+    # Number of tasks.
+    nb_tasks: int = 0
+
+    # Either number of classes per task, or a list specifying for
+    # every task the amount of new classes.
+    increment: Union[int, List[int]] = list_field(
+        2, type=int, nargs="*", alias="n_classes_per_task"
+    )
+    # A different task size applied only for the first task.
+    # Desactivated if `increment` is a list.
+    initial_increment: int = 0
+    # An optional custom class order, used for NC.
+    class_order: Optional[List[int]] = constant(None)
+    # Either number of classes per task, or a list specifying for
+    # every task the amount of new classes (defaults to the value of
+    # `increment`).
+    test_increment: Optional[Union[List[int], int]] = constant(None)
+    # A different task size applied only for the first test task.
+    # Desactivated if `test_increment` is a list. Defaults to the
+    # value of `initial_increment`.
+    test_initial_increment: Optional[int] = constant(None)
+    # An optional custom class order for testing, used for NC.
+    # Defaults to the value of `class_order`.
+    test_class_order: Optional[List[int]] = constant(None)
+
+    def __post_init__(self):
+        super().__post_init__()
+        # IDEA: We could reuse the training loop from Incremental, if we modify it so it
+        # discriminates between "phases" and "tasks".
+
+    @property
+    def phases(self) -> int:
+        return 1
+
+    def setup(self, stage=None, *args, **kwargs):
+        super().setup(stage=stage, *args, **kwargs)
+
+    def train_loop(self, method: Method):
+        """Runs a multi-task training loop, wether in RL or CL.
+        
+        IDEA: We could probably do it the same way in both RL and SL:
+        1. Create the 'datasets' for all the tasks;
+        2. "concatenate"+"Shuffle" the "datasets":
+            - in SL: ConcatDataset / shuffle the datasets
+            - in RL: Create a true `MultiTaskEnvironment` that accepts a list of envs as
+              an input and alternates between environments at each episode.
+              (either round-robin style, or randomly)
+        """
+        logger.info(f"Starting training")
+        # Creating the dataloaders ourselves (rather than passing 'self' as
+        # the datamodule)
+        # TODO: Pass the train_dataloader and val_dataloader methods, rather than the envs?
+        task_train_loader = self.train_dataloader()
+        task_valid_loader = self.val_dataloader()
+        success = method.fit(train_env=task_train_loader, valid_env=task_valid_loader,)
+        task_train_loader.close()
+        task_valid_loader.close()
+
+    def train_dataloader(
+        self, batch_size: int = None, num_workers: int = None
+    ) -> PassiveEnvironment:
+        """Returns a DataLoader for the training dataset.
+
+        This dataloader will yield batches which will very likely contain data from
+        multiple different tasks, and will contain task labels.
+
+        Parameters
+        ----------
+        batch_size : int, optional
+            Batch size to use. Defaults to None, in which case the value of
+            `self.batch_size` is used.
+        num_workers : int, optional
+            Number of workers to use. Defaults to None, in which case the value of
+            `self.num_workers` is used.
+
+        Returns
+        -------
+        PassiveEnvironment
+            A "Passive" Dataloader/gym.Env. 
+        """
+        if not self.has_prepared_data:
+            self.prepare_data()
+        if not self.has_setup_fit:
+            self.setup("fit")
+
+        dataset = ConcatDataset(self.train_datasets)
+
+        batch_size = batch_size if batch_size is not None else self.batch_size
+        num_workers = num_workers if num_workers is not None else self.num_workers
+        # TODO: Add some kind of Wrapper around the dataset to make it
+        # semi-supervised.
+        env = PassiveEnvironment(
+            dataset,
+            split_batch_fn=self.split_batch_function(training=True),
+            observation_space=self.observation_space,
+            action_space=self.action_space,
+            reward_space=self.reward_space,
+            pin_memory=True,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            shuffle=True,
+        )
+
+        if self.config.render:
+            env = RenderEnvWrapper(env)
+
+        if self.train_transforms:
+            # TODO: Check that the transforms aren't already being applied in the
+            # 'dataset' portion.
+            env = TransformObservation(env, f=self.train_transforms)
+
+        if self.train_env:
+            # Close the previous train environment, if any.
+            self.train_env.close()
+        self.train_env = env
+        return self.train_env
+
+    def val_dataloader(
+        self, batch_size: int = None, num_workers: int = None
+    ) -> PassiveEnvironment:
+        """Returns a DataLoader for the validation dataset.
+
+        This dataloader will yield batches which will very likely contain data from
+        multiple different tasks, and will contain task labels.
+
+        Parameters
+        ----------
+        batch_size : int, optional
+            Batch size to use. Defaults to None, in which case the value of
+            `self.batch_size` is used.
+        num_workers : int, optional
+            Number of workers to use. Defaults to None, in which case the value of
+            `self.num_workers` is used.
+
+        Returns
+        -------
+        PassiveEnvironment
+            A "Passive" Dataloader/gym.Env. 
+        """
+        super().val_dataloader
+        if not self.has_prepared_data:
+            self.prepare_data()
+        if not self.has_setup_fit:
+            self.setup("fit")
+
+        dataset = ConcatDataset(self.val_datasets)
+
+        batch_size = batch_size if batch_size is not None else self.batch_size
+        num_workers = num_workers if num_workers is not None else self.num_workers
+        env = PassiveEnvironment(
+            dataset,
+            split_batch_fn=self.split_batch_function(training=True),
+            observation_space=self.observation_space,
+            action_space=self.action_space,
+            reward_space=self.reward_space,
+            pin_memory=True,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            shuffle=True,
+        )
+
+        if self.config.render:
+            env = RenderEnvWrapper(env)
+
+        if self.val_transforms:
+            # TODO: Check that the transforms aren't already being applied in the
+            # 'dataset' portion.
+            env = TransformObservation(env, f=self.val_transforms)
+
+        if self.val_env:
+            # Close the previous environment, if it exists.
+            self.val_env.close()
+        self.val_env = env
+        return self.val_env
+        super().test_dataloader
+
+    def test_dataloader(
+        self, batch_size: int = None, num_workers: int = None
+    ) -> PassiveEnvironment:
+        """Returns a DataLoader for the test dataset.
+
+        This dataloader will yield batches which will very likely contain data from
+        multiple different tasks, and will contain task labels.
+
+        Unlike the train and validation environments, the test environment will not
+        yield rewards until the action has been sent to it using either `send` (when
+        iterating in the DataLoader-style) or `step` (when interacting with the
+        environment in the gym.Env style). For more info, take a look at the
+        `PassiveEnvironment` class.
+        
+        Parameters
+        ----------
+        batch_size : int, optional
+            Batch size to use. Defaults to None, in which case the value of
+            `self.batch_size` is used.
+        num_workers : int, optional
+            Number of workers to use. Defaults to None, in which case the value of
+            `self.num_workers` is used.
+
+        Returns
+        -------
+        PassiveEnvironment
+            A "Passive" Dataloader/gym.Env. 
+        """
+        if not self.has_prepared_data:
+            self.prepare_data()
+        if not self.has_setup_test:
+            self.setup("test")
+
+        batch_size = batch_size if batch_size is not None else self.batch_size
+        num_workers = num_workers if num_workers is not None else self.num_workers
+
+        # Join all the test datasets.
+        dataset = ConcatDataset(self.test_datasets)
+
+        env = PassiveEnvironment(
+            dataset,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            split_batch_fn=self.split_batch_function(training=False),
+            observation_space=self.observation_space,
+            action_space=self.action_space,
+            reward_space=self.reward_space,
+            pretend_to_be_active=True,
+        )
+        if self.test_transforms:
+            env = TransformObservation(env, f=self.test_transforms)
+
+        # TODO: Configure the 'monitoring' dir properly.
+        test_dir = "results"
+        test_loop_max_steps = len(dataset) // (env.batch_size or 1)
+        test_env = ClassIncrementalTestEnvironment(
+            env,
+            directory=test_dir,
+            step_limit=test_loop_max_steps,
+            force=True,
+            config=self.config,
+        )
+
+        if self.test_env:
+            self.test_env.close()
+        self.test_env = test_env
+        return self.test_env
+
+    def test_loop(self, method: Method) -> "IncrementalSetting.Results":
+        """ Runs a multi-task test loop and returns the Results.
+        """
+        test_env = self.test_dataloader()
+        try:
+            # If the Method has `test` defined, use it.
+            method.test(test_env)
+            test_env.close()
+            # Get the metrics from the test environment
+            test_results: Results = test_env.get_results()
+            print(f"Test results: {test_results}")
+            return test_results
+
+        except NotImplementedError:
+            logger.info(
+                f"Will query the method for actions at each step, "
+                f"since it doesn't implement a `test` method."
+            )
+
+        obs = test_env.reset()
+
+        # TODO: Do we always have a maximum number of steps? or of episodes?
+        # Will it work the same for Supervised and Reinforcement learning?
+        max_steps: int = getattr(test_env, "step_limit", None)
+
+        # Reset on the last step is causing trouble, since the env is closed.
+        pbar = tqdm.tqdm(itertools.count(), total=max_steps, desc="Test")
+        episode = 0
+        for step in pbar:
+            if test_env.is_closed():
+                logger.debug(f"Env is closed")
+                break
+            # logger.debug(f"At step {step}")
+            action = method.get_actions(obs, test_env.action_space)
+
+            # logger.debug(f"action: {action}")
+            # TODO: Remove this:
+            if isinstance(action, Actions):
+                action = action.y_pred
+            if isinstance(action, Tensor):
+                action = action.cpu().numpy()
+
+            obs, reward, done, info = test_env.step(action)
+
+            if done and not test_env.is_closed():
+                # logger.debug(f"end of test episode {episode}")
+                obs = test_env.reset()
+                episode += 1
+
+        test_env.close()
+        test_results = test_env.get_results()
+
+        return test_results
+        # if not self.task_labels_at_test_time:
+        #     # TODO: move this wrapper to common/wrappers.
+        #     test_env = RemoveTaskLabelsWrapper(test_env)
+

--- a/sequoia/settings/passive/cl/task_incremental/multi_task/multi_task_setting.py
+++ b/sequoia/settings/passive/cl/task_incremental/multi_task/multi_task_setting.py
@@ -13,11 +13,11 @@ from sequoia.settings.assumptions.incremental import TestEnvironment
 from sequoia.settings.base import Method
 from sequoia.settings.passive.cl.class_incremental_setting import \
     ClassIncrementalTestEnvironment
+from sequoia.settings.passive.cl.objects import Observations, Actions, Rewards
 from sequoia.settings.passive.passive_environment import PassiveEnvironment
 from sequoia.utils import get_logger
 from sequoia.utils.utils import constant
-from ..task_incremental_setting import (Actions, Observations, Rewards,
-                                        TaskIncrementalSetting)
+from ..task_incremental_setting import TaskIncrementalSetting
 
 logger = get_logger(__file__)
 

--- a/sequoia/settings/passive/cl/task_incremental/multi_task/multi_task_setting_test.py
+++ b/sequoia/settings/passive/cl/task_incremental/multi_task/multi_task_setting_test.py
@@ -1,0 +1,71 @@
+"""
+TODO: Tests for the multi-task SL setting.
+
+- Has only one train/test 'phase'
+    - The nb_tasks attribute should still reflect the number of tasks.
+- on_task_switch should never be called during training
+- (not so sure during testing)
+- Task labels should be available for both training and testing.
+- Classes shouldn't be relabeled.
+
+"""
+
+from .multi_task_setting import MultiTaskSetting
+from sequoia.common.spaces import NamedTupleSpace, Image
+from sequoia.settings import Environment
+from gym.spaces import Discrete
+import numpy as np
+import itertools
+import torch
+
+def test_multitask_setting():
+    setting = MultiTaskSetting(dataset="mnist")
+
+    assert setting.phases == 1
+    assert setting.nb_tasks == 5
+    assert setting.observation_space == NamedTupleSpace(
+        x=Image(0.0, 1.0, (3, 28, 28), np.float32), task_labels=Discrete(5)
+    )
+    assert setting.action_space == Discrete(10)
+
+    def check_is_multitask_env(env: Environment, has_rewards: bool):
+        # dataloader-style:
+        for i, (observations, rewards) in itertools.islice(enumerate(env), 10):
+            assert isinstance(observations, MultiTaskSetting.Observations)
+            assert len(set(observations.task_labels.cpu().tolist())) > 1
+            if has_rewards:
+                assert isinstance(rewards, MultiTaskSetting.Rewards)
+                # Check that there is no relabelling happening, by checking that there are
+                # more different y's then there are usually classes in each batch.
+                assert len(set(rewards.y.cpu().tolist())) > setting.n_classes_per_task
+            else:
+                assert rewards is None
+
+        # gym-style interaction:
+        obs = env.reset()
+        assert env.observation_space.contains(obs.numpy())
+        done = False
+        steps = 0
+        while not done and steps < 10:
+            action = setting.Actions(y_pred=torch.randint(10, [env.batch_size]))
+            # BUG: convert_tensors seems to be causing issues again: We shouldn't have
+            # to manually convert obs to numpy before checking `obs in obs_space`.
+            # TODO: Also not super clean that we can't just do `action in action_space`.
+            # assert action.numpy() in env.action_space
+            assert action.y_pred.numpy() in env.action_space
+            obs, reward, done, info = env.step(action)
+            assert obs.numpy() in env.observation_space
+            assert reward.y in env.reward_space
+            steps += 1
+            assert done is False
+        assert steps == 10
+    
+    with setting.train_dataloader(batch_size=32, num_workers=0) as train_env:
+        check_is_multitask_env(train_env, has_rewards=True)
+
+    with setting.val_dataloader(batch_size=32, num_workers=0) as val_env:
+        check_is_multitask_env(val_env, has_rewards=True)
+
+    # FIXME: Wait, actually, this test environment, will it be shuffled, or not?
+    with setting.test_dataloader(batch_size=32, num_workers=0) as test_env:
+        check_is_multitask_env(test_env, has_rewards=False)

--- a/sequoia/settings/passive/cl/task_incremental/multi_task/multi_task_setting_test.py
+++ b/sequoia/settings/passive/cl/task_incremental/multi_task/multi_task_setting_test.py
@@ -9,14 +9,16 @@ TODO: Tests for the multi-task SL setting.
 - Classes shouldn't be relabeled.
 
 """
+import itertools
+
+import numpy as np
+import pytest
+import torch
+from gym.spaces import Discrete
+from sequoia.common.spaces import Image, NamedTupleSpace
+from sequoia.settings import Environment
 
 from .multi_task_setting import MultiTaskSetting
-from sequoia.common.spaces import NamedTupleSpace, Image
-from sequoia.settings import Environment
-from gym.spaces import Discrete
-import numpy as np
-import itertools
-import torch
 
 
 def check_is_multitask_env(env: Environment, has_rewards: bool):

--- a/sequoia/settings/passive/cl/task_incremental/multi_task/multi_task_setting_test.py
+++ b/sequoia/settings/passive/cl/task_incremental/multi_task/multi_task_setting_test.py
@@ -16,7 +16,7 @@ import pytest
 import torch
 from gym.spaces import Discrete
 from sequoia.common.spaces import Image, NamedTupleSpace
-from sequoia.settings import Environment
+from sequoia.settings import Environment, Actions
 
 from .multi_task_setting import MultiTaskSetting
 
@@ -40,7 +40,7 @@ def check_is_multitask_env(env: Environment, has_rewards: bool):
     done = False
     steps = 0
     while not done and steps < 10:
-        action = setting.Actions(y_pred=torch.randint(10, [env.batch_size]))
+        action = Actions(y_pred=torch.randint(10, [env.batch_size]))
         # BUG: convert_tensors seems to be causing issues again: We shouldn't have
         # to manually convert obs to numpy before checking `obs in obs_space`.
         # TODO: Also not super clean that we can't just do `action in action_space`.

--- a/sequoia/settings/passive/cl/task_incremental/multi_task/multi_task_setting_test.py
+++ b/sequoia/settings/passive/cl/task_incremental/multi_task/multi_task_setting_test.py
@@ -18,6 +18,40 @@ import numpy as np
 import itertools
 import torch
 
+
+def check_is_multitask_env(env: Environment, has_rewards: bool):
+    # dataloader-style:
+    for i, (observations, rewards) in itertools.islice(enumerate(env), 10):
+        assert isinstance(observations, MultiTaskSetting.Observations)
+        assert len(set(observations.task_labels.cpu().tolist())) > 1
+        if has_rewards:
+            assert isinstance(rewards, MultiTaskSetting.Rewards)
+            # Check that there is no relabelling happening, by checking that there are
+            # more different y's then there are usually classes in each batch.
+            assert len(set(rewards.y.cpu().tolist())) > 2
+        else:
+            assert rewards is None
+
+    # gym-style interaction:
+    obs = env.reset()
+    assert env.observation_space.contains(obs.numpy())
+    done = False
+    steps = 0
+    while not done and steps < 10:
+        action = setting.Actions(y_pred=torch.randint(10, [env.batch_size]))
+        # BUG: convert_tensors seems to be causing issues again: We shouldn't have
+        # to manually convert obs to numpy before checking `obs in obs_space`.
+        # TODO: Also not super clean that we can't just do `action in action_space`.
+        # assert action.numpy() in env.action_space
+        assert action.y_pred.numpy() in env.action_space
+        obs, reward, done, info = env.step(action)
+        assert obs.numpy() in env.observation_space
+        assert reward.y in env.reward_space
+        steps += 1
+        assert done is False
+    assert steps == 10
+
+
 def test_multitask_setting():
     setting = MultiTaskSetting(dataset="mnist")
 
@@ -28,43 +62,23 @@ def test_multitask_setting():
     )
     assert setting.action_space == Discrete(10)
 
-    def check_is_multitask_env(env: Environment, has_rewards: bool):
-        # dataloader-style:
-        for i, (observations, rewards) in itertools.islice(enumerate(env), 10):
-            assert isinstance(observations, MultiTaskSetting.Observations)
-            assert len(set(observations.task_labels.cpu().tolist())) > 1
-            if has_rewards:
-                assert isinstance(rewards, MultiTaskSetting.Rewards)
-                # Check that there is no relabelling happening, by checking that there are
-                # more different y's then there are usually classes in each batch.
-                assert len(set(rewards.y.cpu().tolist())) > setting.n_classes_per_task
-            else:
-                assert rewards is None
-
-        # gym-style interaction:
-        obs = env.reset()
-        assert env.observation_space.contains(obs.numpy())
-        done = False
-        steps = 0
-        while not done and steps < 10:
-            action = setting.Actions(y_pred=torch.randint(10, [env.batch_size]))
-            # BUG: convert_tensors seems to be causing issues again: We shouldn't have
-            # to manually convert obs to numpy before checking `obs in obs_space`.
-            # TODO: Also not super clean that we can't just do `action in action_space`.
-            # assert action.numpy() in env.action_space
-            assert action.y_pred.numpy() in env.action_space
-            obs, reward, done, info = env.step(action)
-            assert obs.numpy() in env.observation_space
-            assert reward.y in env.reward_space
-            steps += 1
-            assert done is False
-        assert steps == 10
-    
     with setting.train_dataloader(batch_size=32, num_workers=0) as train_env:
         check_is_multitask_env(train_env, has_rewards=True)
 
     with setting.val_dataloader(batch_size=32, num_workers=0) as val_env:
         check_is_multitask_env(val_env, has_rewards=True)
+
+
+@pytest.mark.xfail(reason="test environments still operate in a 'sequential tasks' way")
+def test_multitask_setting_test_env():
+    setting = MultiTaskSetting(dataset="mnist")
+
+    assert setting.phases == 1
+    assert setting.nb_tasks == 5
+    assert setting.observation_space == NamedTupleSpace(
+        x=Image(0.0, 1.0, (3, 28, 28), np.float32), task_labels=Discrete(5)
+    )
+    assert setting.action_space == Discrete(10)
 
     # FIXME: Wait, actually, this test environment, will it be shuffled, or not?
     with setting.test_dataloader(batch_size=32, num_workers=0) as test_env:


### PR DESCRIPTION
Adds `MultiTaskSetting`, as a variant of the Task-Incremental Setting, where the datasets of all tasks are concatenated and shuffled. 

Currently, the batches contain a mix of data from all tasks. Would it be better to instead have one batch of data from task 0, then one batch from task 1, exhausting the dataloaders in a round-robin fashion?

I'm thinking it could make it a bit easier to implement a custom Method using a multi-head model. (FYI the BaselineMethod works just fine on this, so we could also change it in the future). 

@optimass @oleksost  Any thoughts?

Here's the current structure of the tree:
```
├── active
│   └── continual
│       └── incremental
│           └── task_incremental
│               └── stationary
├── assumptions
├── base
├── passive
│   └── cl
│       ├── domain_incremental
│       │   └── iid -> ../task_incremental/iid
│       └── task_incremental
│           ├── iid
│           └── multi_task    <--- (new) ----
```