### PR TITLE
Restrict HPO search space of SB3 Methods (LR only)

### DIFF
--- a/sequoia/methods/stable_baselines3_methods/a2c.py
+++ b/sequoia/methods/stable_baselines3_methods/a2c.py
@@ -137,8 +137,8 @@ class A2CMethod(StableBaselines3Method):
             #   continuous actions
             # Therefore we remove related entries in the search space, so they keep
             # their default values.
-            search_space.pop("use_sde")
-            search_space.pop("sde_sample_freq")
+            search_space.pop("use_sde", None)
+            search_space.pop("sde_sample_freq", None)
         return search_space
 
 

--- a/sequoia/methods/stable_baselines3_methods/base.py
+++ b/sequoia/methods/stable_baselines3_methods/base.py
@@ -315,7 +315,10 @@ class StableBaselines3Method(Method, ABC, target_setting=ContinualRLSetting):
             An orion-formatted search space dictionary, mapping from hyper-parameter
             names (str) to their priors (str), or to nested dicts of the same form.
         """
-        return self.hparams.get_orion_space()
+        search_space = self.hparams.get_orion_space()
+        # See issue #150: The search space could be constrained to just learning rate
+        # for now, apparently.
+        return {"learning_rate": search_space["learning_rate"]}
 
     def adapt_to_new_hparams(self, new_hparams: Dict[str, Any]) -> None:
         """Adapts the Method when it receives new Hyper-Parameters to try for a new run.

--- a/sequoia/methods/stable_baselines3_methods/ppo.py
+++ b/sequoia/methods/stable_baselines3_methods/ppo.py
@@ -162,8 +162,8 @@ class PPOMethod(StableBaselines3Method):
             #   continuous actions
             # Therefore we remove related entries in the search space, so they keep
             # their default values.
-            search_space.pop("use_sde")
-            search_space.pop("sde_sample_freq")
+            search_space.pop("use_sde", None)
+            search_space.pop("sde_sample_freq", None)
         return search_space
 
 


### PR DESCRIPTION
Fixes #150 by dropping all keys of the search space dict, appart from
the learning rate.

Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>