### PR TITLE
Fix bugs with sequoia_sweep and wandb

### DIFF
--- a/sequoia/common/config/wandb_config.py
+++ b/sequoia/common/config/wandb_config.py
@@ -79,7 +79,7 @@ class WandbConfig(Serializable):
 
     # Identifier unique to each individual wandb run. When given, will try to
     # resume the corresponding run, generates a new ID each time.
-    run_id: str = field(default_factory=wandb.util.generate_id)
+    run_id: Optional[str] = None
 
     # An run number is used to differentiate different iterations of the same experiment.
     # Runs with the same name can be later grouped with wandb to produce stderr plots.

--- a/sequoia/methods/baseline_method.py
+++ b/sequoia/methods/baseline_method.py
@@ -222,9 +222,15 @@ class BaselineMethod(Method, Serializable, Parseable, target_setting=Setting):
                 # TODO: Add 'proper' transforms for cartpole, specifically?
                 from sequoia.common.transforms import Transforms
 
-                setting.train_transforms.append(Transforms.resize_64x64)
-                setting.val_transforms.append(Transforms.resize_64x64)
-                setting.test_transforms.append(Transforms.resize_64x64)
+                transforms = [
+                    Transforms.three_channels,
+                    Transforms.to_tensor,
+                    Transforms.resize_64x64,
+                ]
+                setting.transforms = transforms
+                setting.train_transforms = transforms
+                setting.val_transforms = transforms
+                setting.test_transforms = transforms
 
             # Configure the baseline specifically for an RL setting.
             # TODO: Select which output head to use from the command-line?

--- a/sequoia/methods/models/baseline_model/baseline_model.py
+++ b/sequoia/methods/models/baseline_model/baseline_model.py
@@ -24,6 +24,7 @@ from torchvision import models as tv_models
 from sequoia.settings import Setting, ActiveSetting, PassiveSetting, Environment
 from sequoia.common.config import Config
 from sequoia.common.loss import Loss
+from sequoia.common.spaces import Image
 from sequoia.methods.aux_tasks.auxiliary_task import AuxiliaryTask
 from sequoia.methods.models.output_heads import (ActorCriticHead,
                                                  ClassificationHead,
@@ -198,14 +199,9 @@ class BaselineModel(SemiSupervisedModel,
         """
         # The observations should come from a batched environment. If they are not, we
         # add a batch dimension, which we will then remove.
-        # BUG: The observation space of the Setting doesn't correspond to the shapes of
-        # the observations.
-        single_obs_space = self.observation_space
-        single_image_space = single_obs_space[0]
-        # Check if the observations are batched or not.
         assert isinstance(observations.x, (Tensor, np.ndarray))
-        # assert isinstance(single_obs_space.x, Image)
-        not_batched = len(observations.x.shape) == len(single_obs_space[0].shape)
+        # Check if the observations are batched or not.
+        not_batched = not self._are_batched(observations)
         if not_batched:
             observations = observations.with_batch_dimension()
 

--- a/sequoia/methods/models/baseline_model/multihead_model.py
+++ b/sequoia/methods/models/baseline_model/multihead_model.py
@@ -140,11 +140,11 @@ class MultiHeadModel(BaseModel[SettingType]):
             self.batch_size = observations.batch_size
             logger.debug(f"Setting batch_size to {self.batch_size}.")
 
-        # Just testing things out here.
         assert isinstance(observations, self.Observations), observations
-        single_observation_space = self.observation_space
-        if observations[0].shape == single_observation_space[0].shape:
-            raise RuntimeError("Observations should be batched!")
+        if not self._are_batched(observations):
+            raise RuntimeError(
+                f"Observations should be batched, but have shapes {observations.shapes}"
+            )
 
         assert not isinstance(observations.task_labels, int), observations.shapes
         # Get the task labels from the observation.

--- a/sequoia/settings/assumptions/incremental.py
+++ b/sequoia/settings/assumptions/incremental.py
@@ -52,12 +52,12 @@ class IncrementalSetting(ContinualSetting):
     """ Mixin that defines methods that are common to all 'incremental'
     settings, where the data is separated into tasks, and where you may not
     always get the task labels.
-    
+
     Concretely, this holds the train and test loops that are common to the
     ClassIncrementalSetting (highest node on the Passive side) and ContinualRL
     (highest node on the Active side), therefore this setting, while abstract,
-    is quite important. 
-    
+    is quite important.
+
     """
 
     Results: ClassVar[Type[Results]] = IncrementalResults
@@ -120,12 +120,12 @@ class IncrementalSetting(ContinualSetting):
         self._start_time: Optional[float] = None
         self._end_time: Optional[float] = None
         self._setting_logged_to_wandb: bool = False
-    
+
     @property
     def phases(self) -> int:
         """The number of training 'phases', i.e. how many times `method.fit` will be
         called.
-        
+
         Defaults to the number of tasks, but may be different, for instance in so-called
         Multi-Task Settings, this is set to 1.
         """
@@ -134,11 +134,11 @@ class IncrementalSetting(ContinualSetting):
     @property
     def current_task_id(self) -> Optional[int]:
         """ Get the current task id.
-        
+
         TODO: Do we want to return None if the task labels aren't currently
         available? (at either Train or Test time?) Or if we 'detect' if
         this is being called from the method?
-        
+
         TODO: This property doesn't really make sense in the Multi-Task SL or RL
         settings.
         """
@@ -205,7 +205,7 @@ class IncrementalSetting(ContinualSetting):
         method.set_training()
 
         self._start_time = time.process_time()
-        
+
         for task_id in range(self.phases):
             logger.info(
                 f"Starting training"
@@ -218,6 +218,7 @@ class IncrementalSetting(ContinualSetting):
             # the datamodule):
             task_train_env = self.train_dataloader()
             task_valid_env = self.val_dataloader()
+
             method.fit(
                 train_env=task_train_env, valid_env=task_valid_env,
             )
@@ -320,11 +321,11 @@ class IncrementalSetting(ContinualSetting):
 
         The idea is that this loop should be exactly the same, regardless of if
         you're on the RL or the CL side of the tree.
-        
+
         NOTE: If `self.known_task_boundaries_at_test_time` is `True` and the
         method has the `on_task_switch` callback defined, then a callback
         wrapper is added that will invoke the method's `on_task_switch` and pass
-        it the task id (or `None` if `not self.task_labels_available_at_test_time`) 
+        it the task id (or `None` if `not self.task_labels_available_at_test_time`)
         when a task boundary is encountered.
 
         This `on_task_switch` 'callback' wrapper gets added the same way for
@@ -508,7 +509,7 @@ class TestEnvironment(gym.wrappers.Monitor, IterableWrapper, ABC):
     @abstractmethod
     def get_results(self) -> Results:
         """ Return how well the Method was applied on this environment.
-        
+
         In RL, this would be based on the mean rewards, while in supervised
         learning it could be the average accuracy, for instance.
 

--- a/sequoia/settings/assumptions/incremental.py
+++ b/sequoia/settings/assumptions/incremental.py
@@ -274,16 +274,15 @@ class IncrementalSetting(ContinualSetting):
                 run_name += f"_{self.nb_tasks}t"
             self.wandb.run_name = run_name
 
-        run = self.wandb.wandb_init()
-
-        wandb.config["setting"] = setting_name
-        wandb.config["method"] = method_name
+        run: Run = self.wandb.wandb_init()
+        run.config["setting"] = setting_name
+        run.config["method"] = method_name
         for k, value in self.to_dict().items():
             if not k.startswith("_"):
-                wandb.config[f"setting/{k}"] = value
+                run.config[f"setting/{k}"] = value
 
-        wandb.summary["setting"] = self.get_name()
-        wandb.summary["method"] = method.get_name()
+        run.summary["setting"] = self.get_name()
+        run.summary["method"] = method.get_name()
         assert wandb.run is run
         return run
 

--- a/sequoia/settings/base/bases.py
+++ b/sequoia/settings/base/bases.py
@@ -732,12 +732,12 @@ class Method(Generic[SettingType], Parseable, ABC):
                 with StringIO() as s:
                     traceback.print_exc(file=s)
                     s.seek(0)
-                    logger.error(s.read())
-                logger.error("-" * 60)
+                    logger.error(red(s.read()))
+                logger.error(red("-" * 60))
+                failed_trials += 1
                 logger.error(red(f"({failed_trials} failed trials so far). "))
 
                 experiment.release(trial)
-                failed_trials += 1
             else:
                 # Report the results to Orion:
                 orion_result = dict(


### PR DESCRIPTION
- Fixes #155

TODOs:
- Test with all the methods, on all the settings...
Since that is unfeasable (for now) with my current setup, I'll settle instead for something like:
RL: 
- [X] EWC - IncrementalRL
    - [X] Monsterkong
    - [x] Cartpole (state)
- [x]  DQN - IncrementalRL
    - [x] Monsterkong
    - [x] Cartpole (state)
- [x]  PPO - IncrementalRL
    - [x] Monsterkong
    - [ ] Cartpole (state)
- [ ]  A2C - IncrementalRL
    - [ ] Monsterkong
    - [ ] Cartpole (state)
SL:
- [ ] Baseline - ClassIncrementalSetting
    - [ ] MNIST
    - [ ] Synbols?
- [ ] EWC - ClassIncrementalSetting
    - [ ] MNIST
    - [ ] Synbols?


The main issues are being caused by the fact that the Setting is reused between runs, and so for instance if a Method did something like:
```python
def configure(self, setting: Setting):
    setting.train_transforms.append(Transforms.resize_64x64) # <-- BAD
```
then the Setting "accumulates" state between runs, which can cause a bunch of issues.

I will try to figure out a way to instead re-create the setting each time, which will probably save us a lot of trouble in the long run.

For now this works though.

Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>