### PR TITLE
Add Episodes and reward/step to log dict

### DIFF
--- a/sequoia/common/metrics/rl_metrics.py
+++ b/sequoia/common/metrics/rl_metrics.py
@@ -72,15 +72,15 @@ class EpisodeMetrics(Metrics):
 
     def to_log_dict(self, verbose: bool = False):
         log_dict = {
+            "Episodes": self.n_episodes,
             "Mean reward per episode": self.mean_episode_reward,
+            "Mean reward per step": self.mean_reward_per_step,
         }
         if verbose:
             log_dict.update(
                 {
-                    "Episodes": self.n_episodes,
                     "Total steps": self.total_steps,
                     "Total reward": self.total_reward,
-                    "Mean reward per step": self.mean_reward_per_step,
                     "Mean episode length": self.mean_episode_length,
                 }
             )


### PR DESCRIPTION
Fixes #162: The mean reward per step and number of episodes should show up in wandb.

@optimass Should we also display those in the "Final" tab?

Here's an example run: https://wandb.ai/sequoia/debug/runs/2dpiiewp?workspace=user-sequoia


Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>