### PR TITLE
Fix SB3 Methods bug, Improve tests, Add TD3, SAC, DDPG

### DIFF
--- a/examples/clcomp21/multihead_classifier_test.py
+++ b/examples/clcomp21/multihead_classifier_test.py
@@ -19,7 +19,7 @@ def test_mnist(mnist_setting: SettingProxy[ClassIncrementalSetting]):
     results: ClassIncrementalSetting.Results
     # There should be an improvement over the Method in `classifier.py`:
     assert 0.80 <= results.average_online_performance.objective <= 1.00
-    assert 0.20 <= results.average_final_performance.objective <= 0.60
+    assert 0.50 <= results.average_final_performance.objective <= 1.00
 
 
 @slow

--- a/examples/clcomp21/sb3_example_test.py
+++ b/examples/clcomp21/sb3_example_test.py
@@ -4,14 +4,14 @@ from sequoia.conftest import slow
 from sequoia.settings.active import IncrementalRLSetting, RLSetting
 from sequoia.settings.passive import ClassIncrementalSetting
 
-from .sb3_example import CustomPPOMethod
+from .sb3_example import CustomPPOMethod, CustomPPOModel
 
 
 @pytest.mark.timeout(120)
 def test_cartpole_state(cartpole_state_setting: SettingProxy[RLSetting]):
     """ Applies this Method to a simple cartpole-state setting.
     """
-    method = CustomPPOMethod()
+    method = CustomPPOMethod(hparams=CustomPPOModel.HParams(n_steps=64))
     results = cartpole_state_setting.apply(method)
     assert results.to_log_dict()
 
@@ -49,7 +49,6 @@ def test_RL_track(rl_track_setting: SettingProxy[IncrementalRLSetting]):
     results: ClassIncrementalSetting.Results
     online_perf = results.average_online_performance
     # TODO: get an estimate of the upper bound of the random method on the RL track.
-    TODO = 1_000  # this is way too large.
-    assert 0 < online_perf.objective < TODO
+    assert 0 < online_perf.objective
     final_perf = results.average_final_performance
-    assert 0 < final_perf.objective < TODO
+    assert 0 < final_perf.objective

--- a/sequoia/common/gym_wrappers/action_limit.py
+++ b/sequoia/common/gym_wrappers/action_limit.py
@@ -61,5 +61,7 @@ class ActionLimit(ActionCounter):
         # BUG: If we dont use >=, then iteration with EnvDataset doesn't work.
         if self._action_counter >= self._max_steps:
             self.close()
+            done = True
+            info["truncated"] = True
 
         return obs, reward, done, info

--- a/sequoia/common/gym_wrappers/action_limit.py
+++ b/sequoia/common/gym_wrappers/action_limit.py
@@ -61,7 +61,7 @@ class ActionLimit(ActionCounter):
         # BUG: If we dont use >=, then iteration with EnvDataset doesn't work.
         if self._action_counter >= self._max_steps:
             self.close()
-            done = True
-            info["truncated"] = True
+            # done = True
+            # info["truncated"] = True
 
         return obs, reward, done, info

--- a/sequoia/common/gym_wrappers/multi_task_environment_test.py
+++ b/sequoia/common/gym_wrappers/multi_task_environment_test.py
@@ -50,8 +50,8 @@ def test_task_schedule():
 
 
 @pytest.mark.parametrize("environment_name", supported_environments)
-def test_multi_task(environment_name: str):   
-    original = gym.make(environment_name)  
+def test_multi_task(environment_name: str):
+    original = gym.make(environment_name)
     env = MultiTaskEnvironment(original)
     env.reset()
     env.seed(123)
@@ -83,7 +83,7 @@ def test_monitor_env(environment_name):
     )
     env.seed(123)
     env.reset()
-    
+
     plt.ion()
 
     task_param_values: List[Dict] = []
@@ -109,7 +109,7 @@ def test_update_task():
     """Test that using update_task changes the given values in the environment
     and in the current_task dict, and that when a value isn't passed to
     update_task, it isn't reset to its default but instead keeps its previous
-    value. 
+    value.
     """
     original = gym.make("CartPole-v0")
     env = MultiTaskEnvironment(original)
@@ -123,7 +123,7 @@ def test_update_task():
     assert env.length == 1.0
     assert env.current_task["gravity"] == env.gravity == 20.0
     env.close()
-    
+
 
 def test_add_task_dict_to_info():
     """ Test that the 'info' dict contains the task dict. """
@@ -184,19 +184,19 @@ def test_add_task_id_to_obs():
     )
     env.seed(123)
     env.reset()
-    
+
     assert env.observation_space == NamedTupleSpace(
         x=original.observation_space,
-        task_labels=spaces.Discrete(4),   
+        task_labels=spaces.Discrete(4),
     )
-    
-    
+
+
     for step in range(100):
         obs, _, done, info = env.step(env.action_space.sample())
         # env.render()
 
         x, task_id = obs
-        
+
         if 0 <= step < 10:
             assert env.length == starting_length and env.gravity == starting_gravity
             assert task_id == 0, step
@@ -204,11 +204,11 @@ def test_add_task_id_to_obs():
         elif 10 <= step < 20:
             assert env.length == 0.1
             assert task_id == 1, step
-            
+
         elif 20 <= step < 30:
             assert env.length == 0.2 and env.gravity == -12.0
             assert task_id == 2, step
-            
+
         elif step >= 30:
             assert env.length == starting_length and env.gravity == 0.9
             assert task_id == 3, step
@@ -243,7 +243,7 @@ def test_starting_step_and_max_step():
     )
     env.seed(123)
     env.reset()
-    
+
     assert env.observation_space == NamedTupleSpace(
         x=original.observation_space,
         task_labels=spaces.Discrete(4),
@@ -253,7 +253,7 @@ def test_starting_step_and_max_step():
     # doesn't work.
     env.steps = -123
     assert env.steps == 10
-    
+
     # Trying to set the 'steps' to something greater than the max_steps
     # doesn't work.
     env.steps = 50
@@ -262,18 +262,18 @@ def test_starting_step_and_max_step():
     # Here we reset the steps to 10, and also check that this works.
     env.steps = 10
     assert env.steps == 10
-    
+
     for step in range(0, 100):
         # The environment started at an offset of 10.
         assert env.steps == max(min(step + 10, 19), 10)
-        
+
         obs, _, done, info = env.step(env.action_space.sample())
         # env.render()
 
         x, task_id = obs
 
         # Check that we're always stuck between 10 and 20
-        assert 10 <= env.steps < 20 
+        assert 10 <= env.steps < 20
         assert env.length == 0.1
         assert task_id == 1, step
 
@@ -298,7 +298,7 @@ def test_task_id_is_added_even_when_no_known_task_schedule():
     )
     env.seed(123)
     env.reset()
-    
+
     assert env.observation_space == NamedTupleSpace(
         x=original.observation_space,
         task_labels=spaces.Discrete(1),
@@ -330,11 +330,11 @@ def test_task_schedule_monsterkong():
         400: {"level": 4},
     }, add_task_id_to_obs=True)
     obs = env.reset()
-    
+
     # img, task_labels = obs
     assert obs[1] == 0
     assert env.get_level() == 0
-    
+
     for i in range(500):
         obs, reward, done, info = env.step(env.action_space.sample())
         assert obs[1] == i // 100
@@ -344,7 +344,7 @@ def test_task_schedule_monsterkong():
         if done:
             print(f"End of episode at step {i}")
             obs = env.reset()
-    
+
     assert obs[1] == 4
     assert env.level == 4
     # level stays the same even after reaching that objective.
@@ -363,12 +363,12 @@ def test_task_schedule_monsterkong():
 @monsterkong_required
 def test_task_schedule_with_callables():
     """ Apply functions to the env at a given step.
-    
+
     """
     env: MetaMonsterKongEnv = gym.make("MetaMonsterKong-v1")
     from gym.wrappers import TimeLimit
     env = TimeLimit(env, max_episode_steps=10)
-    
+
     from operator import methodcaller
     env = MultiTaskEnvironment(env, task_schedule={
         0:   methodcaller("set_level", 0),
@@ -378,11 +378,11 @@ def test_task_schedule_with_callables():
         400: methodcaller("set_level", 4),
     }, add_task_id_to_obs=True)
     obs = env.reset()
-    
+
     # img, task_labels = obs
     assert obs[1] == 0
     assert env.get_level() == 0
-    
+
     for i in range(500):
         obs, reward, done, info = env.step(env.action_space.sample())
         assert obs[1] == i // 100
@@ -392,7 +392,7 @@ def test_task_schedule_with_callables():
         if done:
             print(f"End of episode at step {i}")
             obs = env.reset()
-    
+
     assert obs[1] == 4
     assert env.level == 4
     # level stays the same even after reaching that objective.
@@ -428,7 +428,7 @@ def test_random_task_on_each_episode():
         obs = env.reset()
         task_labels.append(obs[1])
     assert len(set(task_labels)) > 1
-    
+
     # Episodes only last 10 steps. Tasks don't have anything to do with the task
     # schedule.
     obs = env.reset()
@@ -437,10 +437,10 @@ def test_random_task_on_each_episode():
         obs, reward, done, info = env.step(env.action_space.sample())
         assert obs[1] == start_task_label
         if i == 9:
-            assert done 
+            assert done
         else:
             assert not done
-    
+
     env.close()
 
 from sequoia.conftest import monsterkong_required
@@ -493,7 +493,7 @@ def env_fn_monsterkong() -> gym.Env:
         new_random_task_on_reset=True,
     )
     return env
-    
+
 
 def env_fn_cartpole() -> gym.Env:
     env = gym.make("CartPole-v0")
@@ -537,7 +537,7 @@ def test_task_sequence_is_reproducible(env: str):
         # Then, we want to check that each run was indentical, for a given seed.
         env = SyncVectorEnv([env_fn for _ in range(batch_size)])
         env.seed(123)
-        
+
         task_ids: List[int] = []
         task_lengths: List[int] = []
         for episode in range(n_episodes_per_run):
@@ -557,8 +557,8 @@ def test_task_sequence_is_reproducible(env: str):
         task_ids_and_lengths = list(zip(task_ids, task_lengths))
         print(f"Task ids and length of each one: {task_ids_and_lengths}")
 
-        assert len(set(task_ids)) > 1, "should have been more than just one task!" 
-        
+        assert len(set(task_ids)) > 1, "should have been more than just one task!"
+
         if not first_results:
             first_results = task_ids_and_lengths
         else:

--- a/sequoia/methods/ewc_method.py
+++ b/sequoia/methods/ewc_method.py
@@ -6,18 +6,16 @@ Likewise, defines the `EwcModel`, which is a very simple subclass of the
 For a more detailed view of exactly how the EwcTask calculates its loss, see
 the `sequoia.methods.aux_tasks.ewc.EwcTask`.
 """
-import sys
-from dataclasses import dataclass
-from typing import Dict, Optional
 import warnings
+from dataclasses import dataclass
+from typing import Optional
+
 from gym.utils import colorize
 from simple_parsing import ArgumentParser, mutable_field
 
-sys.path.extend([".", ".."])
 from sequoia.common.config import Config
 from sequoia.common.config.trainer_config import TrainerConfig
 from sequoia.methods import register_method
-from sequoia.methods.aux_tasks import AuxiliaryTask
 from sequoia.methods.aux_tasks.ewc import EWCTask
 from sequoia.methods.baseline_method import BaselineMethod, BaselineModel
 from sequoia.settings import Setting, TaskIncrementalRLSetting
@@ -37,13 +35,7 @@ class EwcModel(BaselineModel):
     def __init__(self, setting: Setting, hparams: "EwcModel.HParams", config: Config):
         super().__init__(setting=setting, hparams=hparams, config=config)
         self.hp: EwcModel.HParams
-
-    def create_auxiliary_tasks(self) -> Dict[str, AuxiliaryTask]:
-        tasks = super().create_auxiliary_tasks()
-        # NOTE: We don't add it here, since we already do this above in __init__.
-        # We could also add the aux tasks this way as well:
-        tasks["ewc"] = EWCTask(options=self.hp.ewc)
-        return tasks
+        self.add_auxiliary_task(EWCTask(options=self.hp.ewc))
 
     def get_loss(self, forward_pass, rewards=None, loss_name=""):
         return super().get_loss(forward_pass, rewards=rewards, loss_name=loss_name)

--- a/sequoia/methods/ewc_method_test.py
+++ b/sequoia/methods/ewc_method_test.py
@@ -69,7 +69,7 @@ def test_task_incremental_mnist(monkeypatch):
     assert at_all_points_in_time[4][4] != 0
 
     assert 0.95 <= results.average_online_performance.objective
-    assert 0.25 <= results.average_final_performance.objective
+    assert 0.15 <= results.average_final_performance.objective
 
 
 @pytest.mark.parametrize(

--- a/sequoia/methods/models/baseline_model/baseline_model.py
+++ b/sequoia/methods/models/baseline_model/baseline_model.py
@@ -136,16 +136,6 @@ class BaselineModel(
             logger.debug("Hparams:")
             logger.debug(self.hp.dumps(indent="\t"))
 
-        # # Upgrade the type of hparams for the output head, based on the setting.
-        # output_head_type = self.output_head_type(setting)
-        # if not isinstance(self.hp.output_head, output_head_type.HParams):
-        #     self.hp.output_head = self.hp.output_head.upgrade(target_type=output_head_type.HParams)
-        
-        # self.output_head: OutputHead = self.create_output_head(task_id=None)
-
-        # Dictionary of auxiliary tasks.
-        self.tasks: Dict[str, AuxiliaryTask] = self.create_auxiliary_tasks()
-
         for task_name, task in self.tasks.items():
             logger.debug("Auxiliary tasks:")
             assert isinstance(

--- a/sequoia/methods/models/baseline_model/self_supervised_model.py
+++ b/sequoia/methods/models/baseline_model/self_supervised_model.py
@@ -45,7 +45,7 @@ class SelfSupervisedModel(BaseModel[SettingType]):
         super().__init__(setting, hparams, config)
         self.hp: SelfSupervisedModel.HParams
         # Dictionary of auxiliary tasks.
-        self.tasks: Dict[str, AuxiliaryTask] = nn.ModuleDict()
+        self.tasks: Dict[str, AuxiliaryTask] = self.create_auxiliary_tasks()
 
     def get_loss(
         self,

--- a/sequoia/methods/stable_baselines3_methods/__init__.py
+++ b/sequoia/methods/stable_baselines3_methods/__init__.py
@@ -1,4 +1,6 @@
 from .base import StableBaselines3Method, SB3BaseHParams
+from .on_policy_method import OnPolicyMethod, OnPolicyModel
+from .off_policy_method import OffPolicyMethod, OffPolicyModel
 from .policy_wrapper import PolicyWrapper
 from .dqn import DQNMethod, DQNModel
 from .a2c import A2CMethod, A2CModel

--- a/sequoia/methods/stable_baselines3_methods/a2c_test.py
+++ b/sequoia/methods/stable_baselines3_methods/a2c_test.py
@@ -39,4 +39,3 @@ def test_monsterkong():
         method, config=Config(debug=True)
     )
     print(results.summary())
-

--- a/sequoia/methods/stable_baselines3_methods/base.py
+++ b/sequoia/methods/stable_baselines3_methods/base.py
@@ -36,13 +36,14 @@ from sequoia.settings.active.continual.wrappers import (
     RemoveTaskLabelsWrapper,
 )
 from sequoia.utils.logging_utils import get_logger
+from sequoia.utils.serialization import register_decoding_fn
 
 logger = get_logger(__file__)
 
 # "Patch" the _wrap_env function of the BaseAlgorithm class of
 # stable_baselines, to make it recognize the VectorEnv from gym.vector as a
 # vectorized environment.
-## Stable-Baselines3 has a lot of duplicated code from openai gym
+# Stable-Baselines3 has a lot of duplicated code from openai gym
 
 
 def _wrap_env(env: GymEnv, verbose: int = 0, monitor_wrapper: bool = True) -> VecEnv:
@@ -94,6 +95,7 @@ class RemoveInfoWrapper(gym.Wrapper):
     """ Wrapper used to remove the 'info' dict, since there seems to be a bug in sb3
     whenever there is something in the 'info' dict.
     """
+
     def step(self, action):
         obs, rewards, done, info = self.env.step(action)
         info = {}
@@ -163,13 +165,13 @@ class StableBaselines3Method(Method, ABC, target_setting=ContinualRLSetting):
     hparams: SB3BaseHParams = mutable_field(SB3BaseHParams)
 
     # The number of training steps to run per task.
-    # NOTE: This shouldn't be set to more than 1 when applying this method on a
-    # ContinualRLSetting, because we don't currently have a way of "resetting"
+    # NOTE: This shouldn't be set to more than the task length when applying this method
+    # on a ContinualRLSetting, because we don't currently have a way of "resetting"
     # the nonstationarity in the environment, and there is only one task,
     # therefore if we trained for say 10 million steps, while the
     # non-stationarity only lasts for 10_000 steps, we'd have seen an almost
-    # stationary distribution, since the environment would have stopped changing after 10_000 steps.
-    #
+    # stationary distribution, since the environment would have stopped changing after
+    # 10_000 steps.
     train_steps_per_task: int = 10_000
 
     # Evaluate the agent every ``eval_freq`` timesteps (this may vary a little)
@@ -213,11 +215,11 @@ class StableBaselines3Method(Method, ABC, target_setting=ContinualRLSetting):
         # some methods support it, some don't, and it doesn't recognize
         # VectorEnvs from gym.
         setting.batch_size = None
-        # assert False, setting.train_transforms
+
         # BUG: Need to fix an issue when using the CnnPolicy and Atary envs, the
         # input shape isn't what they expect (only 2 channels instead of three
         # apparently.)
-        from sequoia.common.transforms import Transforms
+        # from sequoia.common.transforms import Transforms
         # NOTE: Important to not use any transforms, since the SB3 methods want to get
         # the 'raw' np.uint8 image as an input.
         transforms = [
@@ -329,7 +331,7 @@ class StableBaselines3Method(Method, ABC, target_setting=ContinualRLSetting):
 
         It is required that this method be implemented if you want to perform HPO sweeps
         with Orion.
-        
+
         Parameters
         ----------
         new_hparams : Dict[str, Any]
@@ -361,7 +363,6 @@ class StableBaselines3Method(Method, ABC, target_setting=ContinualRLSetting):
 
 # We do this just to prevent errors when trying to decode the hparams class above, and
 # also to silence the related warnings from simple-parsing's decoding.py module.
-from sequoia.utils.serialization import register_decoding_fn
 
 register_decoding_fn(Type[BasePolicy], lambda v: v)
 register_decoding_fn(Callable, lambda v: v)

--- a/sequoia/methods/stable_baselines3_methods/base.py
+++ b/sequoia/methods/stable_baselines3_methods/base.py
@@ -244,12 +244,12 @@ class StableBaselines3Method(Method, ABC, target_setting=ContinualRLSetting):
                 warnings.warn(
                     RuntimeWarning(
                         f"Can't train for the requested {self.train_steps_per_task} "
-                        f"steps, since we're (currently) only allowed one 'pass' "
-                        f"through the environment (max {setting.steps_per_phase} steps.)"
+                        f"steps, since we're (currently) only allowed a maximum of "
+                        f"{setting.steps_per_phase} steps.)"
                     )
                 )
             # Use as many training steps as possible.
-            self.train_steps_per_task = setting.steps_per_phase
+            self.train_steps_per_task = setting.steps_per_phase - 1
         # Otherwise, we can train basically as long as we want on each task.
 
     def create_model(self, train_env: gym.Env, valid_env: gym.Env) -> BaseAlgorithm:

--- a/sequoia/methods/stable_baselines3_methods/base_test.py
+++ b/sequoia/methods/stable_baselines3_methods/base_test.py
@@ -1,0 +1,69 @@
+from inspect import Parameter, Signature, signature, getsourcefile
+from pathlib import Path
+from typing import Type
+
+import pytest
+from stable_baselines3 import A2C, DDPG, DQN, PPO, SAC, TD3
+from stable_baselines3.common.on_policy_algorithm import OnPolicyAlgorithm
+from stable_baselines3.common.off_policy_algorithm import OffPolicyAlgorithm
+
+from . import (
+    A2CMethod,
+    DDPGMethod,
+    DQNMethod,
+    PPOMethod,
+    SACMethod,
+    TD3Method,
+    OnPolicyMethod,
+    OffPolicyMethod,
+)
+from .base import BaseAlgorithm, StableBaselines3Method
+
+
+@pytest.mark.parametrize(
+    "MethodType, AlgoType",
+    [
+        (OnPolicyMethod, OnPolicyAlgorithm),
+        (OffPolicyMethod, OffPolicyAlgorithm),
+        (A2CMethod, A2C),
+        (DDPGMethod, DDPG),
+        (PPOMethod, PPO),
+        (DQNMethod, DQN),
+        (TD3Method, TD3),
+        (SACMethod, SAC),
+    ],
+)
+def test_hparams_have_same_defaults_as_in_sb3(
+    MethodType: Type[StableBaselines3Method], AlgoType: Type[BaseAlgorithm]
+):
+    hparams = MethodType.Model.HParams()
+    sig: Signature = signature(AlgoType.__init__)
+
+    for attr_name, value_in_hparams in hparams.to_dict().items():
+        params_names = list(sig.parameters.keys())
+        assert attr_name in params_names, f"Hparams has extra field {attr_name}"
+        algo_constructor_parameter = sig.parameters[attr_name]
+        sb3_default = algo_constructor_parameter.default
+        if sb3_default is Parameter.empty:
+            continue
+        if attr_name in "verbose":
+            continue  # ignore the default value of the 'verbose' param which we change.
+
+        if (
+            attr_name == "train_freq"
+            and isinstance(sb3_default, tuple)
+            and len(sb3_default) == 2
+        ):
+            # Convert the default of (1, "steps") to 1, since that's the format we use.
+            if sb3_default[1] == "step":
+                sb3_default = sb3_default[0]
+            if isinstance(value_in_hparams, list):
+                value_in_hparams = tuple(value_in_hparams)
+
+        assert value_in_hparams == sb3_default, (
+            f"{MethodType.__name__} in Sequoia has different default value for "
+            f"hyper-parameter '{attr_name}' than in SB3: \n"
+            f"\t{value_in_hparams} != {sb3_default}\n"
+            f"Path to sequoia implementation: {getsourcefile(MethodType)}\n"
+            f"Path to SB3 implementation: {getsourcefile(AlgoType)}\n"
+        )

--- a/sequoia/methods/stable_baselines3_methods/ddpg.py
+++ b/sequoia/methods/stable_baselines3_methods/ddpg.py
@@ -1,81 +1,53 @@
 """ Method that uses the DDPG model from stable-baselines3 and targets the RL
 settings in the tree.
 """
-import math
-import warnings
 from dataclasses import dataclass
 from typing import Callable, ClassVar, Optional, Type, Union
 
 import gym
 from gym import spaces
-from gym.spaces.utils import flatten_space
 from simple_parsing import mutable_field
 from stable_baselines3.ddpg import DDPG
+from stable_baselines3.common.off_policy_algorithm import TrainFreq
 
-from sequoia.common.hparams import log_uniform, uniform
+from sequoia.common.hparams import log_uniform
 from sequoia.methods import register_method
 from sequoia.settings.active import ContinualRLSetting
 from sequoia.utils.logging_utils import get_logger
 
-from .base import SB3BaseHParams, StableBaselines3Method
+from .off_policy_method import OffPolicyModel, OffPolicyMethod
 logger = get_logger(__file__)
 
 
-class DDPGModel(DDPG):
+class DDPGModel(DDPG, OffPolicyModel):
     """ Customized version of the DDPG model from stable-baselines-3. """
 
     @dataclass
-    class HParams(SB3BaseHParams):
+    class HParams(OffPolicyModel.HParams):
         """ Hyper-parameters of the DDPG Model. """
+        # TODO: Add hparams specific to DDPG here.
         # The learning rate, it can be a function of the current progress (from
         # 1 to 0)
-        learning_rate: Union[float, Callable] = log_uniform(1e-6, 1e-2, default=1e-4)
-        # size of the replay buffer
-        buffer_size: int = uniform(100, 10_000_000, default=1_000_000)
-        # How many steps of the model to collect transitions for before learning
-        # starts.
-        learning_starts: int = 50_000
-        # learning_starts: int = uniform(1_000, 100_000, default=50_000)
+        learning_rate: Union[float, Callable] = log_uniform(1e-6, 1e-2, default=1e-3)
+
+        # The verbosity level: 0 none, 1 training information, 2 debug
+        verbose: int = 0
+
+        train_freq: TrainFreq = (1, "episode")
 
         # Minibatch size for each gradient update
-        batch_size: Optional[int] = 32
-        # batch_size: Optional[int] = categorical(1, 2, 4, 8, 16, 32, 128, default=32)
-
-        # The soft update coefficient ("Polyak update", between 0 and 1) default
-        # 1 for hard update
-        tau: float = 1.0
-        # tau: float = uniform(0., 1., default=1.0)
-
-        # The discount factor
-        gamma: float = 0.99
-        # gamma: float = uniform(0.9, 0.9999, default=0.99)
-
-        # Update the model every ``train_freq`` steps. Set to `-1` to disable.
-        train_freq: int = 10
-        # train_freq: int = categorical(1, 10, 100, 1_000, 10_000, default=10)
+        batch_size: int = 100
 
         # How many gradient steps to do after each rollout (see ``train_freq``
         # and ``n_episodes_rollout``) Set to ``-1`` means to do as many gradient
         # steps as steps done in the environment during the rollout.
-        gradient_steps: int = 1
-        # gradient_steps: int = categorical(-1, 1, default=1)
-
-        # Enable a memory efficient variant of the replay buffer at a cost of
-        # more complexity.
-        # See https://github.com/DLR-RM/stable-baselines3/issues/37#issuecomment-637501195
-        optimize_memory_usage: bool = False
-        # Whether to create a second environment that will be used for
-        # evaluating the agent periodically. (Only available when passing string
-        # for the environment)
-        create_eval_env: bool = False
-        # Whether or not to build the network at the creation
-        # of the instance
-        _init_setup_model: bool = True
+        gradient_steps: int = -1
+        # gradient_steps: int = categorical(1, -1, default=-1)
 
 
 @register_method
 @dataclass
-class DDPGMethod(StableBaselines3Method):
+class DDPGMethod(OffPolicyMethod):
     """ Method that uses the DDPG model from stable-baselines3. """
 
     Model: ClassVar[Type[DDPGModel]] = DDPGModel
@@ -88,108 +60,6 @@ class DDPGMethod(StableBaselines3Method):
 
     def configure(self, setting: ContinualRLSetting):
         super().configure(setting)
-        # TODO: This is mostly just copied from DQN, there is probably need for a new
-        # OffPolicyMethod class that would contain the code common to both?
-    
-        # The default value for the buffer size in the DQN model is WAY too
-        # large, so we re-size it depending on the size of the observations.
-        # NOTE: (issue #156) Only consider the images, not the task labels for these
-        # buffer size calculations (since the task labels might be None and have the
-        # np.object dtype).
-        x_space = setting.observation_space.x
-        flattened_observation_space = flatten_space(x_space)
-        observation_size_bytes = flattened_observation_space.sample().nbytes
-
-        # IF there are more than a few dimensions per observation, then we
-        # should probably reduce the size of the replay buffer according to
-        # the size of the observations.
-        max_buffer_size_bytes = self.max_buffer_size_megabytes * 1024 * 1024
-        max_buffer_length = max_buffer_size_bytes // observation_size_bytes
-
-        if max_buffer_length == 0:
-            raise RuntimeError(
-                f"Couldn't even fit a single observation in the buffer, "
-                f"given the  specified max_buffer_size_megabytes "
-                f"({self.max_buffer_size_megabytes}) and the size of a "
-                f"single observation ({observation_size_bytes} bytes)!"
-            )
-
-        if self.hparams.buffer_size > max_buffer_length:
-            calculated_size_bytes = observation_size_bytes * self.hparams.buffer_size
-            calculated_size_gb = calculated_size_bytes / 1024 ** 3
-            warnings.warn(
-                RuntimeWarning(
-                    f"The selected buffer size ({self.hparams.buffer_size} is "
-                    f"too large! (It would take roughly around "
-                    f"{calculated_size_gb:.3f}Gb to hold  many observations alone! "
-                    f"The buffer size will be capped at {max_buffer_length} "
-                    f"entries."
-                )
-            )
-
-            self.hparams.buffer_size = int(max_buffer_length)
-
-        # NOTE: Need to change some attributes depending on the maximal number of steps
-        # in the environment allowed in the given Setting.
-        if setting.max_steps:
-            logger.info(
-                f"Total training steps are limited to {setting.steps_per_task} steps "
-                f"per task, {setting.max_steps} steps in total."
-            )
-            ten_percent_of_step_budget = setting.steps_per_phase // 10
-
-            if self.hparams.buffer_size > ten_percent_of_step_budget:
-                warnings.warn(
-                    RuntimeWarning(
-                        "Reducing max buffer size to ten percent of the step budget."
-                    )
-                )
-                self.hparams.buffer_size = ten_percent_of_step_budget
-
-            if self.hparams.learning_starts > ten_percent_of_step_budget:
-                logger.info(
-                    f"The model was originally going to use the first "
-                    f"{self.hparams.learning_starts} steps for pure random "
-                    f"exploration, but the setting has a max number of steps set to "
-                    f"{setting.max_steps}, therefore we will limit the number of "
-                    f"exploration steps to 10% of that 'step budget' = "
-                    f"{ten_percent_of_step_budget} steps."
-                )
-                self.hparams.learning_starts = ten_percent_of_step_budget
-                if self.hparams.train_freq != -1:
-                    # Update the model at least 2 times during each task, and at most
-                    # once per step.
-                    self.hparams.train_freq = min(
-                        self.hparams.train_freq, int(0.5 * ten_percent_of_step_budget),
-                    )
-                    self.hparams.train_freq = max(self.hparams.train_freq, 1)
-
-                logger.info(f"Training frequency: {self.hparams.train_freq}")
-
-        logger.info(f"Will use a Replay buffer of size {self.hparams.buffer_size}.")
-
-        if setting.steps_per_phase:
-            assert (
-                isinstance(self.hparams.train_freq, int)
-                or self.hparams.train_freq[1] == "steps"
-            ), "Need the train freq units to be steps for now."
-
-            # NOTE: We limit the number of training steps per task, such that we never
-            # attempt to fill the buffer using more samples than the environment allows.
-            if self.hparams.train_freq > setting.steps_per_phase:
-                self.hparams.n_steps = math.ceil(0.1 * setting.steps_per_phase)
-                logger.info(
-                    f"Capping the n_steps to 10% of step budget length: "
-                    f"{self.hparams.n_steps}"
-                )
-
-            self.train_steps_per_task = min(
-                self.train_steps_per_task,
-                setting.steps_per_phase - self.hparams.train_freq - 1,
-            )
-            logger.info(
-                f"Limitting training steps per task to {self.train_steps_per_task}"
-            )
 
     def create_model(self, train_env: gym.Env, valid_env: gym.Env) -> DDPGModel:
         return self.Model(env=train_env, **self.hparams.to_dict())

--- a/sequoia/methods/stable_baselines3_methods/ddpg.py
+++ b/sequoia/methods/stable_baselines3_methods/ddpg.py
@@ -1,26 +1,76 @@
 """ Method that uses the DDPG model from stable-baselines3 and targets the RL
 settings in the tree.
 """
+import math
+import warnings
 from dataclasses import dataclass
-from typing import ClassVar, Type, Optional
+from typing import Callable, ClassVar, Optional, Type, Union
 
 import gym
 from gym import spaces
+from gym.spaces.utils import flatten_space
 from simple_parsing import mutable_field
 from stable_baselines3.ddpg import DDPG
 
+from sequoia.common.hparams import categorical, log_uniform, uniform
 from sequoia.methods import register_method
 from sequoia.settings.active import ContinualRLSetting
+from sequoia.utils.logging_utils import get_logger
 
 from .base import SB3BaseHParams, StableBaselines3Method
+logger = get_logger(__file__)
 
 
 class DDPGModel(DDPG):
     """ Customized version of the DDPG model from stable-baselines-3. """
+
     @dataclass
     class HParams(SB3BaseHParams):
         """ Hyper-parameters of the DDPG Model. """
-        # TODO: Create the fields from the DDPG constructor arguments.
+        # The learning rate, it can be a function of the current progress (from
+        # 1 to 0)
+        learning_rate: Union[float, Callable] = log_uniform(1e-6, 1e-2, default=1e-4)
+        # size of the replay buffer
+        buffer_size: int = uniform(100, 10_000_000, default=1_000_000)
+        # How many steps of the model to collect transitions for before learning
+        # starts.
+        learning_starts: int = 50_000
+        # learning_starts: int = uniform(1_000, 100_000, default=50_000)
+
+        # Minibatch size for each gradient update
+        batch_size: Optional[int] = 32
+        # batch_size: Optional[int] = categorical(1, 2, 4, 8, 16, 32, 128, default=32)
+
+        # The soft update coefficient ("Polyak update", between 0 and 1) default
+        # 1 for hard update
+        tau: float = 1.0
+        # tau: float = uniform(0., 1., default=1.0)
+
+        # The discount factor
+        gamma: float = 0.99
+        # gamma: float = uniform(0.9, 0.9999, default=0.99)
+
+        # Update the model every ``train_freq`` steps. Set to `-1` to disable.
+        train_freq: int = 10
+        # train_freq: int = categorical(1, 10, 100, 1_000, 10_000, default=10)
+
+        # How many gradient steps to do after each rollout (see ``train_freq``
+        # and ``n_episodes_rollout``) Set to ``-1`` means to do as many gradient
+        # steps as steps done in the environment during the rollout.
+        gradient_steps: int = 1
+        # gradient_steps: int = categorical(-1, 1, default=1)
+
+        # Enable a memory efficient variant of the replay buffer at a cost of
+        # more complexity.
+        # See https://github.com/DLR-RM/stable-baselines3/issues/37#issuecomment-637501195
+        optimize_memory_usage: bool = False
+        # Whether to create a second environment that will be used for
+        # evaluating the agent periodically. (Only available when passing string
+        # for the environment)
+        create_eval_env: bool = False
+        # Whether or not to build the network at the creation
+        # of the instance
+        _init_setup_model: bool = True
 
 
 @register_method
@@ -33,8 +83,113 @@ class DDPGMethod(StableBaselines3Method):
     # Hyper-parameters of the DDPG model.
     hparams: DDPGModel.HParams = mutable_field(DDPGModel.HParams)
 
+    # Approximate limit on the size of the replay buffer, in megabytes.
+    max_buffer_size_megabytes: float = 2_048.0
+
     def configure(self, setting: ContinualRLSetting):
-        super().configure(setting=setting)
+        super().configure(setting)
+        # TODO: This is mostly just copied from DQN, there is probably need for a new
+        # OffPolicyMethod class that would contain the code common to both?
+
+        # The default value for the buffer size in the DQN model is WAY too
+        # large, so we re-size it depending on the size of the observations.
+        # NOTE: (issue #156) Only consider the images, not the task labels for these
+        # buffer size calculations (since the task labels might be None and have the
+        # np.object dtype).
+        x_space = setting.observation_space.x
+        flattened_observation_space = flatten_space(x_space)
+        observation_size_bytes = flattened_observation_space.sample().nbytes
+
+        # IF there are more than a few dimensions per observation, then we
+        # should probably reduce the size of the replay buffer according to
+        # the size of the observations.
+        max_buffer_size_bytes = self.max_buffer_size_megabytes * 1024 * 1024
+        max_buffer_length = max_buffer_size_bytes // observation_size_bytes
+
+        if max_buffer_length == 0:
+            raise RuntimeError(
+                f"Couldn't even fit a single observation in the buffer, "
+                f"given the  specified max_buffer_size_megabytes "
+                f"({self.max_buffer_size_megabytes}) and the size of a "
+                f"single observation ({observation_size_bytes} bytes)!"
+            )
+
+        if self.hparams.buffer_size > max_buffer_length:
+            calculated_size_bytes = observation_size_bytes * self.hparams.buffer_size
+            calculated_size_gb = calculated_size_bytes / 1024 ** 3
+            warnings.warn(
+                RuntimeWarning(
+                    f"The selected buffer size ({self.hparams.buffer_size} is "
+                    f"too large! (It would take roughly around "
+                    f"{calculated_size_gb:.3f}Gb to hold  many observations alone! "
+                    f"The buffer size will be capped at {max_buffer_length} "
+                    f"entries."
+                )
+            )
+
+            self.hparams.buffer_size = int(max_buffer_length)
+
+        # NOTE: Need to change some attributes depending on the maximal number of steps
+        # in the environment allowed in the given Setting.
+        if setting.max_steps:
+            logger.info(
+                f"Total training steps are limited to {setting.steps_per_task} steps "
+                f"per task, {setting.max_steps} steps in total."
+            )
+            ten_percent_of_step_budget = setting.steps_per_phase // 10
+
+            if self.hparams.buffer_size > ten_percent_of_step_budget:
+                warnings.warn(
+                    RuntimeWarning(
+                        "Reducing max buffer size to ten percent of the step budget."
+                    )
+                )
+                self.hparams.buffer_size = ten_percent_of_step_budget
+
+            if self.hparams.learning_starts > ten_percent_of_step_budget:
+                logger.info(
+                    f"The model was originally going to use the first "
+                    f"{self.hparams.learning_starts} steps for pure random "
+                    f"exploration, but the setting has a max number of steps set to "
+                    f"{setting.max_steps}, therefore we will limit the number of "
+                    f"exploration steps to 10% of that 'step budget' = "
+                    f"{ten_percent_of_step_budget} steps."
+                )
+                self.hparams.learning_starts = ten_percent_of_step_budget
+                if self.hparams.train_freq != -1:
+                    # Update the model at least 2 times during each task, and at most
+                    # once per step.
+                    self.hparams.train_freq = min(
+                        self.hparams.train_freq, int(0.5 * ten_percent_of_step_budget),
+                    )
+                    self.hparams.train_freq = max(self.hparams.train_freq, 1)
+
+                logger.info(f"Training frequency: {self.hparams.train_freq}")
+
+        logger.info(f"Will use a Replay buffer of size {self.hparams.buffer_size}.")
+
+        if setting.steps_per_phase:
+            assert (
+                isinstance(self.hparams.train_freq, int)
+                or self.hparams.train_freq[1] == "steps"
+            ), "Need the train freq units to be steps for now."
+
+            # NOTE: We limit the number of training steps per task, such that we never
+            # attempt to fill the buffer using more samples than the environment allows.
+            if self.hparams.train_freq > setting.steps_per_phase:
+                self.hparams.n_steps = math.ceil(0.1 * setting.steps_per_phase)
+                logger.info(
+                    f"Capping the n_steps to 10% of step budget length: "
+                    f"{self.hparams.n_steps}"
+                )
+
+            self.train_steps_per_task = min(
+                self.train_steps_per_task,
+                setting.steps_per_phase - self.hparams.train_freq - 1,
+            )
+            logger.info(
+                f"Limitting training steps per task to {self.train_steps_per_task}"
+            )
 
     def create_model(self, train_env: gym.Env, valid_env: gym.Env) -> DDPGModel:
         return self.Model(env=train_env, **self.hparams.to_dict())
@@ -42,12 +197,11 @@ class DDPGMethod(StableBaselines3Method):
     def fit(self, train_env: gym.Env, valid_env: gym.Env):
         super().fit(train_env=train_env, valid_env=valid_env)
 
-    def get_actions(self,
-                    observations: ContinualRLSetting.Observations,
-                    action_space: spaces.Space) -> ContinualRLSetting.Actions:
+    def get_actions(
+        self, observations: ContinualRLSetting.Observations, action_space: spaces.Space
+    ) -> ContinualRLSetting.Actions:
         return super().get_actions(
-            observations=observations,
-            action_space=action_space,
+            observations=observations, action_space=action_space,
         )
 
     def on_task_switch(self, task_id: Optional[int]) -> None:

--- a/sequoia/methods/stable_baselines3_methods/ddpg.py
+++ b/sequoia/methods/stable_baselines3_methods/ddpg.py
@@ -12,7 +12,7 @@ from gym.spaces.utils import flatten_space
 from simple_parsing import mutable_field
 from stable_baselines3.ddpg import DDPG
 
-from sequoia.common.hparams import categorical, log_uniform, uniform
+from sequoia.common.hparams import log_uniform, uniform
 from sequoia.methods import register_method
 from sequoia.settings.active import ContinualRLSetting
 from sequoia.utils.logging_utils import get_logger
@@ -90,7 +90,7 @@ class DDPGMethod(StableBaselines3Method):
         super().configure(setting)
         # TODO: This is mostly just copied from DQN, there is probably need for a new
         # OffPolicyMethod class that would contain the code common to both?
-
+    
         # The default value for the buffer size in the DQN model is WAY too
         # large, so we re-size it depending on the size of the observations.
         # NOTE: (issue #156) Only consider the images, not the task labels for these

--- a/sequoia/methods/stable_baselines3_methods/ddpg_test.py
+++ b/sequoia/methods/stable_baselines3_methods/ddpg_test.py
@@ -15,7 +15,7 @@ from typing import Type
     "Setting", [ContinualRLSetting, IncrementalRLSetting, TaskIncrementalRLSetting]
 )
 @pytest.mark.parametrize("observe_state", [True, False])
-def test_continuous_mountaincar_state(Setting: Type[Setting], observe_state: bool):
+def test_continuous_mountaincar(Setting: Type[Setting], observe_state: bool):
     method = DDPGMethod()
     setting = Setting(
         dataset="MountainCarContinuous-v0",
@@ -27,4 +27,5 @@ def test_continuous_mountaincar_state(Setting: Type[Setting], observe_state: boo
     results: ContinualRLSetting.Results = setting.apply(
         method, config=Config(debug=True)
     )
+    # TODO: Add some bounds on the expected performance here:
     print(results.summary())

--- a/sequoia/methods/stable_baselines3_methods/ddpg_test.py
+++ b/sequoia/methods/stable_baselines3_methods/ddpg_test.py
@@ -1,6 +1,5 @@
 import pytest
 from sequoia.common.config import Config
-from sequoia.conftest import monsterkong_required
 from sequoia.settings.active import (
     ContinualRLSetting,
     IncrementalRLSetting,
@@ -29,4 +28,3 @@ def test_continuous_mountaincar_state(Setting: Type[Setting], observe_state: boo
         method, config=Config(debug=True)
     )
     print(results.summary())
-

--- a/sequoia/methods/stable_baselines3_methods/ddpg_test.py
+++ b/sequoia/methods/stable_baselines3_methods/ddpg_test.py
@@ -6,37 +6,26 @@ from sequoia.settings.active import (
     IncrementalRLSetting,
     TaskIncrementalRLSetting,
 )
+from sequoia.settings import Setting
 
 from .ddpg import DDPGMethod
+from typing import Type
 
 
-@pytest.mark.xfail(reason="DDPG needs continuous action spaces.")
-def test_cartpole_state():
+@pytest.mark.parametrize(
+    "Setting", [ContinualRLSetting, IncrementalRLSetting, TaskIncrementalRLSetting]
+)
+@pytest.mark.parametrize("observe_state", [True, False])
+def test_continuous_mountaincar_state(Setting: Type[Setting], observe_state: bool):
     method = DDPGMethod()
-    setting = IncrementalRLSetting(
-        dataset="cartpole",
+    setting = Setting(
+        dataset="MountainCarContinuous-v0",
         observe_state_directly=True,
         nb_tasks=2,
         steps_per_task=1_000,
         test_steps_per_task=1_000,
     )
-    results: IncrementalRLSetting.Results = setting.apply(
-        method, config=Config(debug=True)
-    )
-    print(results.summary())
-
-
-@pytest.mark.xfail(reason="DDPG needs continuous action spaces.")
-@monsterkong_required
-def test_monsterkong():
-    method = DDPGMethod()
-    setting = IncrementalRLSetting(
-        dataset="monsterkong",
-        nb_tasks=2,
-        steps_per_task=1_000,
-        test_steps_per_task=1_000,
-    )
-    results: IncrementalRLSetting.Results = setting.apply(
+    results: ContinualRLSetting.Results = setting.apply(
         method, config=Config(debug=True)
     )
     print(results.summary())

--- a/sequoia/methods/stable_baselines3_methods/dqn.py
+++ b/sequoia/methods/stable_baselines3_methods/dqn.py
@@ -1,6 +1,7 @@
 """ Method that uses the DQN model from stable-baselines3 and targets the RL
 settings in the tree.
 """
+import math
 import warnings
 from dataclasses import dataclass
 from typing import Callable, ClassVar, Optional, Type, Union
@@ -8,14 +9,13 @@ from typing import Callable, ClassVar, Optional, Type, Union
 import gym
 from gym import spaces
 from gym.spaces.utils import flatten_space
-from simple_parsing import mutable_field
-from stable_baselines3.dqn import DQN
-
 from sequoia.common.hparams import categorical, log_uniform, uniform
 from sequoia.common.transforms import ChannelsFirst
 from sequoia.methods import register_method
 from sequoia.settings.active import ContinualRLSetting
 from sequoia.utils.logging_utils import get_logger
+from simple_parsing import mutable_field
+from stable_baselines3.dqn import DQN
 
 from .base import SB3BaseHParams, StableBaselines3Method
 
@@ -35,33 +35,42 @@ class DQNModel(DQN):
         # The learning rate, it can be a function of the current progress (from
         # 1 to 0)
         learning_rate: Union[float, Callable] = log_uniform(1e-6, 1e-2, default=1e-4)
+
         # size of the replay buffer
         buffer_size: int = uniform(100, 10_000_000, default=1_000_000)
+
         # How many steps of the model to collect transitions for before learning
         # starts.
         learning_starts: int = 50_000
         # learning_starts: int = uniform(1_000, 100_000, default=50_000)
+
         # Minibatch size for each gradient update
         batch_size: int = 32
         # batch_size: Optional[int] = categorical(1, 2, 4, 8, 16, 32, 128, default=32)
+
         # The soft update coefficient ("Polyak update", between 0 and 1) default
         # 1 for hard update
         tau: float = 1.0
         # tau: float = uniform(0., 1., default=1.0)
+
         # The discount factor
         gamma: float = 0.99
         # gamma: float = uniform(0.9, 0.9999, default=0.99)
+
         # Update the model every ``train_freq`` steps. Set to `-1` to disable.
         train_freq: int = categorical(1, 10, 100, 1_000, 10_000, default=10)
+
         # How many gradient steps to do after each rollout (see ``train_freq``
         # and ``n_episodes_rollout``) Set to ``-1`` means to do as many gradient
         # steps as steps done in the environment during the rollout.
         gradient_steps: int = 1
         # gradient_steps: int = categorical(1, -1, default=1)
+
         # Enable a memory efficient variant of the replay buffer at a cost of
         # more complexity.
         # See https://github.com/DLR-RM/stable-baselines3/issues/37#issuecomment-637501195
         optimize_memory_usage: bool = False
+
         # Update the target network every ``target_update_interval`` environment
         # steps.
         target_update_interval: int = categorical(
@@ -87,6 +96,9 @@ class DQNModel(DQN):
         # Whether or not to build the network at the creation
         # of the instance
         _init_setup_model: bool = True
+
+    def train(self, gradient_steps: int, batch_size: int = 100) -> None:
+        super().train(gradient_steps, batch_size=batch_size)
 
 
 @register_method
@@ -174,8 +186,7 @@ class DQNMethod(StableBaselines3Method):
                     # Update the model at least 2 times during each task, and at most
                     # once per step.
                     self.hparams.train_freq = min(
-                        self.hparams.train_freq,
-                        int(0.5 * ten_percent_of_step_budget),
+                        self.hparams.train_freq, int(0.5 * ten_percent_of_step_budget),
                     )
                     self.hparams.train_freq = max(self.hparams.train_freq, 1)
 
@@ -191,6 +202,29 @@ class DQNMethod(StableBaselines3Method):
                 )
 
         logger.info(f"Will use a Replay buffer of size {self.hparams.buffer_size}.")
+
+        if setting.steps_per_phase:
+            assert (
+                isinstance(self.hparams.train_freq, int)
+                or self.hparams.train_freq[1] == "steps"
+            ), "Need the train freq units to be steps for now."
+
+            # NOTE: We limit the number of training steps per task, such that we never
+            # attempt to fill the buffer using more samples than the environment allows.
+            if self.hparams.train_freq > setting.steps_per_phase:
+                self.hparams.n_steps = math.ceil(0.1 * setting.steps_per_phase)
+                logger.info(
+                    f"Capping the n_steps to 10% of step budget length: "
+                    f"{self.hparams.n_steps}"
+                )
+
+            self.train_steps_per_task = min(
+                self.train_steps_per_task,
+                setting.steps_per_phase - self.hparams.train_freq - 1,
+            )
+            logger.info(
+                f"Limitting training steps per task to {self.train_steps_per_task}"
+            )
 
     def create_model(self, train_env: gym.Env, valid_env: gym.Env) -> DQNModel:
         return self.Model(env=train_env, **self.hparams.to_dict())

--- a/sequoia/methods/stable_baselines3_methods/dqn.py
+++ b/sequoia/methods/stable_baselines3_methods/dqn.py
@@ -1,15 +1,12 @@
 """ Method that uses the DQN model from stable-baselines3 and targets the RL
 settings in the tree.
 """
-import math
-import warnings
 from dataclasses import dataclass
-from typing import Callable, ClassVar, Optional, Type, Union
+from typing import ClassVar, Optional, Type
 
 import gym
 from gym import spaces
-from gym.spaces.utils import flatten_space
-from sequoia.common.hparams import categorical, log_uniform, uniform
+from sequoia.common.hparams import categorical
 from sequoia.common.transforms import ChannelsFirst
 from sequoia.methods import register_method
 from sequoia.settings.active import ContinualRLSetting
@@ -17,59 +14,34 @@ from sequoia.utils.logging_utils import get_logger
 from simple_parsing import mutable_field
 from stable_baselines3.dqn import DQN
 
-from .base import SB3BaseHParams, StableBaselines3Method
-
+from .off_policy_method import OffPolicyMethod, OffPolicyModel
 logger = get_logger(__file__)
 
 
-class DQNModel(DQN):
+class DQNModel(DQN, OffPolicyModel):
     """ Customized version of the DQN model from stable-baselines-3. """
 
     @dataclass
-    class HParams(SB3BaseHParams):
+    class HParams(OffPolicyModel.HParams):
         """ Hyper-parameters of the DQN model from `stable_baselines3`.
 
         The command-line arguments for these are created with simple-parsing.
         """
-
-        # The learning rate, it can be a function of the current progress (from
-        # 1 to 0)
-        learning_rate: Union[float, Callable] = log_uniform(1e-6, 1e-2, default=1e-4)
-
-        # size of the replay buffer
-        buffer_size: int = uniform(100, 10_000_000, default=1_000_000)
-
         # How many steps of the model to collect transitions for before learning
         # starts.
         learning_starts: int = 50_000
-        # learning_starts: int = uniform(1_000, 100_000, default=50_000)
 
         # Minibatch size for each gradient update
         batch_size: int = 32
-        # batch_size: Optional[int] = categorical(1, 2, 4, 8, 16, 32, 128, default=32)
+
+        # Update the model every ``train_freq`` steps. Set to `-1` to disable.
+        train_freq: int = 4
+        # train_freq: int = categorical(1, 10, 100, 1_000, 10_000, default=4)
 
         # The soft update coefficient ("Polyak update", between 0 and 1) default
         # 1 for hard update
         tau: float = 1.0
         # tau: float = uniform(0., 1., default=1.0)
-
-        # The discount factor
-        gamma: float = 0.99
-        # gamma: float = uniform(0.9, 0.9999, default=0.99)
-
-        # Update the model every ``train_freq`` steps. Set to `-1` to disable.
-        train_freq: int = categorical(1, 10, 100, 1_000, 10_000, default=10)
-
-        # How many gradient steps to do after each rollout (see ``train_freq``
-        # and ``n_episodes_rollout``) Set to ``-1`` means to do as many gradient
-        # steps as steps done in the environment during the rollout.
-        gradient_steps: int = 1
-        # gradient_steps: int = categorical(1, -1, default=1)
-
-        # Enable a memory efficient variant of the replay buffer at a cost of
-        # more complexity.
-        # See https://github.com/DLR-RM/stable-baselines3/issues/37#issuecomment-637501195
-        optimize_memory_usage: bool = False
 
         # Update the target network every ``target_update_interval`` environment
         # steps.
@@ -89,13 +61,6 @@ class DQNModel(DQN):
         # The maximum value for the gradient clipping.
         max_grad_norm: float = 10
         # max_grad_norm: float = uniform(1, 100, default=10)
-        # Whether to create a second environment that will be used for
-        # evaluating the agent periodically. (Only available when passing string
-        # for the environment)
-        create_eval_env: bool = False
-        # Whether or not to build the network at the creation
-        # of the instance
-        _init_setup_model: bool = True
 
     def train(self, gradient_steps: int, batch_size: int = 100) -> None:
         super().train(gradient_steps, batch_size=batch_size)
@@ -103,7 +68,7 @@ class DQNModel(DQN):
 
 @register_method
 @dataclass
-class DQNMethod(StableBaselines3Method):
+class DQNMethod(OffPolicyMethod):
     """ Method that uses a DQN model from the stable-baselines3 package. """
 
     Model: ClassVar[Type[DQNModel]] = DQNModel
@@ -116,82 +81,10 @@ class DQNMethod(StableBaselines3Method):
 
     def configure(self, setting: ContinualRLSetting):
         super().configure(setting)
-
-        # The default value for the buffer size in the DQN model is WAY too
-        # large, so we re-size it depending on the size of the observations.
-        # NOTE: (issue #156) Only consider the images, not the task labels for these
-        # buffer size calculations (since the task labels might be None and have the
-        # np.object dtype).
-        x_space = setting.observation_space.x
-        flattened_observation_space = flatten_space(x_space)
-        observation_size_bytes = flattened_observation_space.sample().nbytes
-
-        # IF there are more than a few dimensions per observation, then we
-        # should probably reduce the size of the replay buffer according to
-        # the size of the observations.
-        max_buffer_size_bytes = self.max_buffer_size_megabytes * 1024 * 1024
-        max_buffer_length = max_buffer_size_bytes // observation_size_bytes
-
-        if max_buffer_length == 0:
-            raise RuntimeError(
-                f"Couldn't even fit a single observation in the buffer, "
-                f"given the  specified max_buffer_size_megabytes "
-                f"({self.max_buffer_size_megabytes}) and the size of a "
-                f"single observation ({observation_size_bytes} bytes)!"
-            )
-
-        if self.hparams.buffer_size > max_buffer_length:
-            calculated_size_bytes = observation_size_bytes * self.hparams.buffer_size
-            calculated_size_gb = calculated_size_bytes / 1024 ** 3
-            warnings.warn(
-                RuntimeWarning(
-                    f"The selected buffer size ({self.hparams.buffer_size} is "
-                    f"too large! (It would take roughly around "
-                    f"{calculated_size_gb:.3f}Gb to hold  many observations alone! "
-                    f"The buffer size will be capped at {max_buffer_length} "
-                    f"entries."
-                )
-            )
-
-            self.hparams.buffer_size = int(max_buffer_length)
-
         # NOTE: Need to change some attributes depending on the maximal number of steps
         # in the environment allowed in the given Setting.
-        if setting.max_steps:
-            logger.info(
-                f"Total training steps are limited to {setting.steps_per_task} steps "
-                f"per task, {setting.max_steps} steps in total."
-            )
+        if setting.steps_per_phase:
             ten_percent_of_step_budget = setting.steps_per_phase // 10
-
-            if self.hparams.buffer_size > ten_percent_of_step_budget:
-                warnings.warn(
-                    RuntimeWarning(
-                        "Reducing max buffer size to ten percent of the step budget."
-                    )
-                )
-                self.hparams.buffer_size = ten_percent_of_step_budget
-
-            if self.hparams.learning_starts > ten_percent_of_step_budget:
-                logger.info(
-                    f"The model was originally going to use the first "
-                    f"{self.hparams.learning_starts} steps for pure random "
-                    f"exploration, but the setting has a max number of steps set to "
-                    f"{setting.max_steps}, therefore we will limit the number of "
-                    f"exploration steps to 10% of that 'step budget' = "
-                    f"{ten_percent_of_step_budget} steps."
-                )
-                self.hparams.learning_starts = ten_percent_of_step_budget
-                if self.hparams.train_freq != -1:
-                    # Update the model at least 2 times during each task, and at most
-                    # once per step.
-                    self.hparams.train_freq = min(
-                        self.hparams.train_freq, int(0.5 * ten_percent_of_step_budget),
-                    )
-                    self.hparams.train_freq = max(self.hparams.train_freq, 1)
-
-                logger.info(f"Training frequency: {self.hparams.train_freq}")
-
             if self.hparams.target_update_interval > ten_percent_of_step_budget:
                 # Same for the 'update target network' interval.
                 self.hparams.target_update_interval = ten_percent_of_step_budget // 2
@@ -200,31 +93,6 @@ class DQNMethod(StableBaselines3Method):
                     f"{self.hparams.target_update_interval}, because of the limit on "
                     f"training steps imposed by the Setting."
                 )
-
-        logger.info(f"Will use a Replay buffer of size {self.hparams.buffer_size}.")
-
-        if setting.steps_per_phase:
-            assert (
-                isinstance(self.hparams.train_freq, int)
-                or self.hparams.train_freq[1] == "steps"
-            ), "Need the train freq units to be steps for now."
-
-            # NOTE: We limit the number of training steps per task, such that we never
-            # attempt to fill the buffer using more samples than the environment allows.
-            if self.hparams.train_freq > setting.steps_per_phase:
-                self.hparams.n_steps = math.ceil(0.1 * setting.steps_per_phase)
-                logger.info(
-                    f"Capping the n_steps to 10% of step budget length: "
-                    f"{self.hparams.n_steps}"
-                )
-
-            self.train_steps_per_task = min(
-                self.train_steps_per_task,
-                setting.steps_per_phase - self.hparams.train_freq - 1,
-            )
-            logger.info(
-                f"Limitting training steps per task to {self.train_steps_per_task}"
-            )
 
     def create_model(self, train_env: gym.Env, valid_env: gym.Env) -> DQNModel:
         return self.Model(env=train_env, **self.hparams.to_dict())

--- a/sequoia/methods/stable_baselines3_methods/dqn_test.py
+++ b/sequoia/methods/stable_baselines3_methods/dqn_test.py
@@ -11,11 +11,11 @@ from sequoia.settings.active import (
     TaskIncrementalRLSetting,
 )
 
-from .dqn import DQNMethod
+from .dqn import DQNMethod, DQNModel
 
 
 def test_cartpole_state():
-    method = DQNMethod()
+    method = DQNMethod(hparams=DQNModel.HParams(train_freq=1))
     setting = IncrementalRLSetting(
         dataset="cartpole",
         observe_state_directly=True,
@@ -29,9 +29,10 @@ def test_cartpole_state():
     print(results.summary())
 
 
+@pytest.mark.timeout(60)
 @monsterkong_required
 def test_monsterkong():
-    method = DQNMethod()
+    method = DQNMethod(hparams=DQNModel.HParams(train_freq=1))
     setting = IncrementalRLSetting(
         dataset="monsterkong",
         nb_tasks=2,

--- a/sequoia/methods/stable_baselines3_methods/dqn_test.py
+++ b/sequoia/methods/stable_baselines3_methods/dqn_test.py
@@ -15,7 +15,7 @@ from .dqn import DQNMethod, DQNModel
 
 
 def test_cartpole_state():
-    method = DQNMethod(hparams=DQNModel.HParams(train_freq=1))
+    method = DQNMethod()
     setting = IncrementalRLSetting(
         dataset="cartpole",
         observe_state_directly=True,
@@ -32,7 +32,7 @@ def test_cartpole_state():
 @pytest.mark.timeout(60)
 @monsterkong_required
 def test_monsterkong():
-    method = DQNMethod(hparams=DQNModel.HParams(train_freq=1))
+    method = DQNMethod()
     setting = IncrementalRLSetting(
         dataset="monsterkong",
         nb_tasks=2,

--- a/sequoia/methods/stable_baselines3_methods/dqn_test.py
+++ b/sequoia/methods/stable_baselines3_methods/dqn_test.py
@@ -1,17 +1,12 @@
 import numpy as np
 import pytest
-import torch
 from gym import spaces
 from sequoia.common.config import Config
 from sequoia.common.spaces import Image, NamedTupleSpace, Sparse
 from sequoia.conftest import monsterkong_required
-from sequoia.settings.active import (
-    ContinualRLSetting,
-    IncrementalRLSetting,
-    TaskIncrementalRLSetting,
-)
+from sequoia.settings.active import IncrementalRLSetting
 
-from .dqn import DQNMethod, DQNModel
+from .dqn import DQNMethod
 
 
 def test_cartpole_state():

--- a/sequoia/methods/stable_baselines3_methods/off_policy_method.py
+++ b/sequoia/methods/stable_baselines3_methods/off_policy_method.py
@@ -1,0 +1,228 @@
+""" Base class used to not duplicate the tweaks made all the off-policy algos from SB3.
+"""
+import math
+import warnings
+from dataclasses import dataclass
+from typing import Callable, ClassVar, Optional, Type, Union
+from abc import ABC
+import gym
+from gym import spaces
+from gym.spaces.utils import flatten_space
+from simple_parsing import mutable_field
+from stable_baselines3.common.off_policy_algorithm import OffPolicyAlgorithm
+
+from sequoia.common.hparams import log_uniform, uniform
+from sequoia.settings.active import ContinualRLSetting
+from sequoia.utils.logging_utils import get_logger
+
+from .base import SB3BaseHParams, StableBaselines3Method
+
+logger = get_logger(__file__)
+
+
+class OffPolicyModel(OffPolicyAlgorithm, ABC):
+    """ Tweaked version of the OffPolicyAlgorithm from SB3. """
+
+    @dataclass
+    class HParams(SB3BaseHParams):
+        """ Hyper-parameters common to all off-policy algos from SB3. """
+
+        # The learning rate, it can be a function of the current progress (from
+        # 1 to 0)
+        learning_rate: Union[float, Callable] = log_uniform(1e-6, 1e-2, default=1e-4)
+        # size of the replay buffer
+        buffer_size: int = uniform(100, 10_000_000, default=1_000_000)
+
+        # How many steps of the model to collect transitions for before learning
+        # starts.
+        learning_starts: int = 100
+
+        # Minibatch size for each gradient update
+        batch_size: int = 256
+        # batch_size: int = categorical(1, 2, 4, 8, 16, 32, 128, default=32)
+
+        # The soft update coefficient ("Polyak update", between 0 and 1) default
+        # 1 for hard update
+        tau: float = 0.005
+        # tau: float = uniform(0., 1., default=1.0)
+
+        # The discount factor
+        gamma: float = 0.99
+        # gamma: float = uniform(0.9, 0.9999, default=0.99)
+
+        # Update the model every ``train_freq`` steps. Set to `-1` to disable.
+        train_freq: int = 1
+        # train_freq: int = categorical(1, 10, 100, 1_000, 10_000, default=10)
+
+        # How many gradient steps to do after each rollout (see ``train_freq``
+        # and ``n_episodes_rollout``) Set to ``-1`` means to do as many gradient
+        # steps as steps done in the environment during the rollout.
+        gradient_steps: int = 1
+        # gradient_steps: int = categorical(1, -1, default=1)
+
+        # Enable a memory efficient variant of the replay buffer at a cost of
+        # more complexity.
+        # See https://github.com/DLR-RM/stable-baselines3/issues/37#issuecomment-637501195
+        optimize_memory_usage: bool = False
+
+        # Whether to create a second environment that will be used for
+        # evaluating the agent periodically. (Only available when passing string
+        # for the environment)
+        create_eval_env: bool = False
+
+        # The verbosity level: 0 no output, 1 info, 2 debug
+        verbose: int = 1
+
+
+@dataclass
+class OffPolicyMethod(StableBaselines3Method, ABC):
+    """ ABC for a Method that uses an off-policy Algorithm from SB3. """
+
+    # Type of model to use. This has to be overwritten in a subclass.
+    Model: ClassVar[Type[OffPolicyModel]] = OffPolicyModel
+    # Hyper-parameters of the DDPG model.
+    hparams: OffPolicyModel.HParams = mutable_field(OffPolicyModel.HParams)
+    # Approximate limit on the size of the replay buffer, in megabytes.
+    max_buffer_size_megabytes: float = 2_048.0
+
+    def configure(self, setting: ContinualRLSetting):
+        super().configure(setting)
+        # The default value for the buffer size in the DQN model is WAY too
+        # large, so we re-size it depending on the size of the observations.
+        # NOTE: (issue #156) Only consider the images, not the task labels for these
+        # buffer size calculations (since the task labels might be None and have the
+        # np.object dtype).
+        x_space = setting.observation_space.x
+        flattened_observation_space = flatten_space(x_space)
+        observation_size_bytes = flattened_observation_space.sample().nbytes
+
+        # IF there are more than a few dimensions per observation, then we
+        # should probably reduce the size of the replay buffer according to
+        # the size of the observations.
+        max_buffer_size_bytes = self.max_buffer_size_megabytes * 1024 * 1024
+        max_buffer_length = max_buffer_size_bytes // observation_size_bytes
+
+        if max_buffer_length == 0:
+            raise RuntimeError(
+                f"Couldn't even fit a single observation in the buffer, "
+                f"given the  specified max_buffer_size_megabytes "
+                f"({self.max_buffer_size_megabytes}) and the size of a "
+                f"single observation ({observation_size_bytes} bytes)!"
+            )
+
+        if self.hparams.buffer_size > max_buffer_length:
+            calculated_size_bytes = observation_size_bytes * self.hparams.buffer_size
+            calculated_size_gb = calculated_size_bytes / 1024 ** 3
+            warnings.warn(
+                RuntimeWarning(
+                    f"The selected buffer size ({self.hparams.buffer_size} is "
+                    f"too large! (It would take roughly around "
+                    f"{calculated_size_gb:.3f}Gb to hold  many observations alone! "
+                    f"The buffer size will be capped at {max_buffer_length} "
+                    f"entries."
+                )
+            )
+
+            self.hparams.buffer_size = int(max_buffer_length)
+
+        # NOTE: Need to change some attributes depending on the maximal number of steps
+        # in the environment allowed in the given Setting.
+        if setting.max_steps:
+            logger.info(
+                f"Total training steps are limited to {setting.steps_per_task} steps "
+                f"per task, {setting.max_steps} steps in total."
+            )
+            ten_percent_of_step_budget = setting.steps_per_phase // 10
+
+            if self.hparams.buffer_size > ten_percent_of_step_budget:
+                warnings.warn(
+                    RuntimeWarning(
+                        "Reducing max buffer size to ten percent of the step budget."
+                    )
+                )
+                self.hparams.buffer_size = ten_percent_of_step_budget
+
+            if self.hparams.learning_starts > ten_percent_of_step_budget:
+                logger.info(
+                    f"The model was originally going to use the first "
+                    f"{self.hparams.learning_starts} steps for pure random "
+                    f"exploration, but the setting has a max number of steps set to "
+                    f"{setting.max_steps}, therefore we will limit the number of "
+                    f"exploration steps to 10% of that 'step budget' = "
+                    f"{ten_percent_of_step_budget} steps."
+                )
+                self.hparams.learning_starts = ten_percent_of_step_budget
+                if self.hparams.train_freq != -1:
+                    # Update the model at least 2 times during each task, and at most
+                    # once per step.
+                    self.hparams.train_freq = min(
+                        self.hparams.train_freq, int(0.5 * ten_percent_of_step_budget),
+                    )
+                    self.hparams.train_freq = max(self.hparams.train_freq, 1)
+
+                logger.info(f"Training frequency: {self.hparams.train_freq}")
+
+        logger.info(f"Will use a Replay buffer of size {self.hparams.buffer_size}.")
+
+        if setting.steps_per_phase:
+            if not isinstance(self.hparams.train_freq, int):
+                if self.hparams.train_freq[1] == "step":
+                    self.hparams.train_freq = self.hparams.train_freq[0]
+                else:
+                    assert self.hparams.train_freq[1] == "episode"
+
+                    # Use some value based of the maximum episode length if available,
+                    # else use a "reasonable" default value.
+                    # TODO: Double-check that this makes sense.
+                    if setting.max_episode_steps:
+                        self.hparams.train_freq = setting.max_episode_steps
+                    else:
+                        self.hparams.train_freq = 10
+
+                    warnings.warn(
+                        RuntimeWarning(
+                            f"Need the training frequency units to be steps for now! "
+                            f"(Train freq has been changed to every "
+                            f"{self.hparams.train_freq} steps)."
+                        )
+                    )
+
+            # NOTE: We limit the number of training steps per task, such that we never
+            # attempt to fill the buffer using more samples than the environment allows.
+            if self.hparams.train_freq > setting.steps_per_phase:
+                self.hparams.n_steps = math.ceil(0.1 * setting.steps_per_phase)
+                logger.info(
+                    f"Capping the n_steps to 10% of step budget length: "
+                    f"{self.hparams.n_steps}"
+                )
+
+            self.train_steps_per_task = min(
+                self.train_steps_per_task,
+                setting.steps_per_phase - self.hparams.train_freq - 1,
+            )
+            logger.info(
+                f"Limitting training steps per task to {self.train_steps_per_task}"
+            )
+
+    def create_model(self, train_env: gym.Env, valid_env: gym.Env) -> OffPolicyModel:
+        return self.Model(env=train_env, **self.hparams.to_dict())
+
+    def fit(self, train_env: gym.Env, valid_env: gym.Env):
+        super().fit(train_env=train_env, valid_env=valid_env)
+
+    def get_actions(
+        self, observations: ContinualRLSetting.Observations, action_space: spaces.Space
+    ) -> ContinualRLSetting.Actions:
+        return super().get_actions(
+            observations=observations, action_space=action_space,
+        )
+
+    def on_task_switch(self, task_id: Optional[int]) -> None:
+        """ Called when switching tasks in a CL setting.
+
+        If task labels are available, `task_id` will correspond to the index of
+        the new task. Otherwise, if task labels aren't available, `task_id` will
+        be `None`.
+
+        todo: use this to customize how your method handles task transitions.
+        """

--- a/sequoia/methods/stable_baselines3_methods/on_policy_method.py
+++ b/sequoia/methods/stable_baselines3_methods/on_policy_method.py
@@ -1,7 +1,7 @@
-""" Method that uses the A2C model from stable-baselines3 and targets the RL
-settings in the tree.
+""" Base class used to not duplicate the tweaks made all the on-policy algos from SB3.
 """
 import math
+from abc import ABC
 from dataclasses import dataclass
 from typing import Callable, ClassVar, Dict, Mapping, Optional, Type, Union
 
@@ -9,41 +9,27 @@ import gym
 import torch
 from gym import spaces
 from simple_parsing import mutable_field
-from stable_baselines3.a2c import A2C
+from stable_baselines3.common.on_policy_algorithm import OnPolicyAlgorithm
 
-from sequoia.common.hparams import log_uniform, uniform
-from sequoia.methods import register_method
+from sequoia.common.hparams import uniform, log_uniform
 from sequoia.settings.active import ContinualRLSetting
-from sequoia.utils import get_logger
+from sequoia.utils.logging_utils import get_logger
 
-from .on_policy_method import OnPolicyMethod, OnPolicyModel
+from .base import SB3BaseHParams, StableBaselines3Method
 
 logger = get_logger(__file__)
 
 
-class A2CModel(A2C, OnPolicyModel):
-    """ Advantage Actor Critic (A2C) model imported from stable-baselines3.
-
-    Paper: https://arxiv.org/abs/1602.01783
-    Code: The SB3 implementation borrows code from
-    https://github.com/ikostrikov/pytorch-a2c-ppo-acktr-gail and
-    and Stable Baselines (https://github.com/hill-a/stable-baselines)
-
-    Introduction to A2C:
-    https://hackernoon.com/intuitive-rl-intro-to-advantage-actor-critic-a2c-4ff545978752
-    """
+class OnPolicyModel(OnPolicyAlgorithm, ABC):
+    """ Tweaked version of the OnPolicyAlgorithm from SB3. """
 
     @dataclass
-    class HParams(OnPolicyModel.HParams):
-        """ Hyper-parameters of the A2C Model.
+    class HParams(SB3BaseHParams):
+        """ Hyper-parameters common to all on-policy algos from SB3. """
 
-        TODO: Set actual 'good' priors for these hyper-parameters, as these were set
-        somewhat arbitrarily. (They do however use the same defaults as in SB3).
-        """
         # learning rate for the optimizer, it can be a function of the current
         # progress remaining (from 1 to 0)
-        learning_rate: Union[float, Callable] = log_uniform(1e-7, 1e-2, default=7e-4)
-
+        learning_rate: Union[float, Callable] = log_uniform(1e-7, 1e-2, default=1e-3)
         # The number of steps to run for each environment per update (i.e. batch size
         # is n_steps * n_env where n_env is number of environment copies running in
         # parallel)
@@ -72,15 +58,6 @@ class A2CModel(A2C, OnPolicyModel):
         max_grad_norm: float = 0.5
         # max_grad_norm: float = uniform(0.1, 10, default=0.5)
 
-        # RMSProp epsilon. It stabilizes square root computation in denominator of
-        # RMSProp update.
-        rms_prop_eps: float = 1e-5
-        # rms_prop_eps: float = log_uniform(1e-7, 1e-3, default=1e-5)
-
-        # Whether to use RMSprop (default) or Adam as optimizer
-        use_rms_prop: bool = True
-        # use_rms_prop: bool = categorical(True, False, default=True)
-
         # Whether to use generalized State Dependent Exploration (gSDE) instead of
         # action noise exploration (default: False)
         use_sde: bool = False
@@ -90,10 +67,6 @@ class A2CModel(A2C, OnPolicyModel):
         # Default: -1 (only sample at the beginning of the rollout)
         sde_sample_freq: int = -1
         # sde_sample_freq: int = categorical(-1, 1, 5, 10, default=-1)
-
-        # Whether to normalize or not the advantage
-        normalize_advantage: bool = False
-        # normalize_advantage: bool = categorical(True, False, default=False)
 
         # The log location for tensorboard (if None, no logging)
         tensorboard_log: Optional[str] = None
@@ -106,7 +79,7 @@ class A2CModel(A2C, OnPolicyModel):
         # policy_kwargs: Optional[Dict[str, Any]] = None
 
         # The verbosity level: 0 no output, 1 info, 2 debug
-        verbose: int = 0
+        verbose: int = 1
 
         # Seed for the pseudo random generators
         seed: Optional[int] = None
@@ -120,18 +93,14 @@ class A2CModel(A2C, OnPolicyModel):
         # _init_setup_model: bool = True
 
 
-@register_method
 @dataclass
-class A2CMethod(OnPolicyMethod):
+class OnPolicyMethod(StableBaselines3Method, ABC):
     """ Method that uses the A2C model from stable-baselines3. """
 
-    # changing the 'name' in this case here, because the default name would be
-    # 'a_2_c'.
-    name: ClassVar[str] = "a2c"
-    Model: ClassVar[Type[A2CModel]] = A2CModel
+    Model: ClassVar[Type[OnPolicyModel]] = OnPolicyModel
 
-    # Hyper-parameters of the A2C model.
-    hparams: A2CModel.HParams = mutable_field(A2CModel.HParams)
+    # Hyper-parameters of the model/algorithm.
+    hparams: OnPolicyModel.HParams = mutable_field(OnPolicyModel.HParams)
 
     def configure(self, setting: ContinualRLSetting):
         super().configure(setting=setting)
@@ -152,7 +121,7 @@ class A2CMethod(OnPolicyMethod):
                 f"Limitting training steps per task to {self.train_steps_per_task}"
             )
 
-    def create_model(self, train_env: gym.Env, valid_env: gym.Env) -> A2CModel:
+    def create_model(self, train_env: gym.Env, valid_env: gym.Env) -> OnPolicyModel:
         return self.Model(env=train_env, **self.hparams.to_dict())
 
     def fit(self, train_env: gym.Env, valid_env: gym.Env):
@@ -188,8 +157,3 @@ class A2CMethod(OnPolicyMethod):
             search_space.pop("use_sde", None)
             search_space.pop("sde_sample_freq", None)
         return search_space
-
-
-if __name__ == "__main__":
-    results = A2CMethod.main()
-    print(results)

--- a/sequoia/methods/stable_baselines3_methods/ppo_test.py
+++ b/sequoia/methods/stable_baselines3_methods/ppo_test.py
@@ -16,11 +16,11 @@ def test_cartpole_state():
         steps_per_task=5_000,
         test_steps_per_task=1_000,
     )
-    results: IncrementalRLSetting.Results = setting.apply(
+    results = setting.apply(
         method, config=Config(debug=True)
     )
     print(results.summary())
-    assert 150 < results.average_final_performance.mean_reward_per_episode
+    assert 150 < results.average_final_performance.mean_episode_reward
 
 
 def test_incremental_cartpole_state():
@@ -29,12 +29,13 @@ def test_incremental_cartpole_state():
         dataset="cartpole",
         observe_state_directly=True,
         nb_tasks=2,
-        steps_per_task=1_000,
+        steps_per_task=2_000,
         test_steps_per_task=1_000,
     )
     results: IncrementalRLSetting.Results = setting.apply(
         method, config=Config(debug=True)
     )
+    assert 100 < results.average_final_performance.mean_episode_reward
     print(results.summary())
 
 

--- a/sequoia/methods/stable_baselines3_methods/ppo_test.py
+++ b/sequoia/methods/stable_baselines3_methods/ppo_test.py
@@ -2,17 +2,14 @@ import pytest
 from sequoia.common.config import Config
 from sequoia.conftest import monsterkong_required
 from sequoia.settings.active import (
-    ContinualRLSetting,
     IncrementalRLSetting,
-    TaskIncrementalRLSetting,
 )
 
-from .ppo import PPOMethod, PPOModel
+from .ppo import PPOMethod
 
 
 def test_cartpole_state():
-    # Steps seems to be batch_size * n_steps * n_epochs, but I might be wrong.
-    method = PPOMethod(hparams=PPOModel.HParams(batch_size=10, n_steps=10, n_epochs=2))
+    method = PPOMethod()
     setting = IncrementalRLSetting(
         dataset="cartpole",
         observe_state_directly=True,
@@ -29,7 +26,7 @@ def test_cartpole_state():
 @pytest.mark.timeout(120)
 @monsterkong_required
 def test_monsterkong():
-    method = PPOMethod(hparams=PPOModel.HParams(batch_size=10, n_steps=10, n_epochs=2))
+    method = PPOMethod()
     setting = IncrementalRLSetting(
         dataset="monsterkong",
         nb_tasks=2,
@@ -40,4 +37,3 @@ def test_monsterkong():
         method, config=Config(debug=True)
     )
     print(results.summary())
-

--- a/sequoia/methods/stable_baselines3_methods/ppo_test.py
+++ b/sequoia/methods/stable_baselines3_methods/ppo_test.py
@@ -7,11 +7,12 @@ from sequoia.settings.active import (
     TaskIncrementalRLSetting,
 )
 
-from .ppo import PPOMethod
+from .ppo import PPOMethod, PPOModel
 
 
 def test_cartpole_state():
-    method = PPOMethod()
+    # Steps seems to be batch_size * n_steps * n_epochs, but I might be wrong.
+    method = PPOMethod(hparams=PPOModel.HParams(batch_size=10, n_steps=10, n_epochs=2))
     setting = IncrementalRLSetting(
         dataset="cartpole",
         observe_state_directly=True,
@@ -28,7 +29,7 @@ def test_cartpole_state():
 @pytest.mark.timeout(120)
 @monsterkong_required
 def test_monsterkong():
-    method = PPOMethod()
+    method = PPOMethod(hparams=PPOModel.HParams(batch_size=10, n_steps=10, n_epochs=2))
     setting = IncrementalRLSetting(
         dataset="monsterkong",
         nb_tasks=2,

--- a/sequoia/methods/stable_baselines3_methods/ppo_test.py
+++ b/sequoia/methods/stable_baselines3_methods/ppo_test.py
@@ -2,14 +2,29 @@ import pytest
 from sequoia.common.config import Config
 from sequoia.conftest import monsterkong_required
 from sequoia.settings.active import (
-    IncrementalRLSetting,
+    IncrementalRLSetting, RLSetting
 )
 
-from .ppo import PPOMethod
+from .ppo import PPOMethod, PPOModel
 
 
 def test_cartpole_state():
-    method = PPOMethod()
+    method = PPOMethod(hparams=PPOModel.HParams(n_steps=64))
+    setting = RLSetting(
+        dataset="cartpole",
+        observe_state_directly=True,
+        steps_per_task=5_000,
+        test_steps_per_task=1_000,
+    )
+    results: IncrementalRLSetting.Results = setting.apply(
+        method, config=Config(debug=True)
+    )
+    print(results.summary())
+    assert 150 < results.average_final_performance.mean_reward_per_episode
+
+
+def test_incremental_cartpole_state():
+    method = PPOMethod(hparams=PPOModel.HParams(n_steps=64))
     setting = IncrementalRLSetting(
         dataset="cartpole",
         observe_state_directly=True,

--- a/sequoia/methods/stable_baselines3_methods/sac.py
+++ b/sequoia/methods/stable_baselines3_methods/sac.py
@@ -1,88 +1,51 @@
 """ Method that uses the SAC model from stable-baselines3 and targets the RL
 settings in the tree.
 """
-
-import math
-import warnings
 from dataclasses import dataclass
-from typing import Callable, ClassVar, Optional, Type, Union
+from typing import ClassVar, Optional, Type, Union, Callable
 
 import gym
 from gym import spaces
-from gym.spaces.utils import flatten_space
 from simple_parsing import mutable_field
-from stable_baselines3.sac import SAC
+from stable_baselines3.sac.sac import SAC
 
-from sequoia.common.hparams import log_uniform, uniform
 from sequoia.methods import register_method
-from sequoia.methods.stable_baselines3_methods.base import (
-    SB3BaseHParams,
-    StableBaselines3Method,
-)
+from sequoia.common.hparams import log_uniform
 from sequoia.settings.active import ContinualRLSetting
 from sequoia.utils.logging_utils import get_logger
-
+from .off_policy_method import OffPolicyMethod, OffPolicyModel
 
 logger = get_logger(__file__)
 
 
-class SACModel(SAC):
+class SACModel(SAC, OffPolicyModel):
     """ Customized version of the SAC model from stable-baselines-3. """
 
     @dataclass
-    class HParams(SB3BaseHParams):
+    class HParams(OffPolicyModel.HParams):
         """ Hyper-parameters of the SAC Model. """
-
-        # TODO: Create the fields from the SAC constructor arguments.
         # The learning rate, it can be a function of the current progress (from
         # 1 to 0)
-        learning_rate: Union[float, Callable] = log_uniform(1e-6, 1e-2, default=1e-4)
-        # size of the replay buffer
-        buffer_size: int = uniform(100, 10_000_000, default=1_000_000)
-        # How many steps of the model to collect transitions for before learning
-        # starts.
-        learning_starts: int = 50_000
-        # learning_starts: int = uniform(1_000, 100_000, default=50_000)
-
-        # Minibatch size for each gradient update
-        batch_size: Optional[int] = 32
-        # batch_size: Optional[int] = categorical(1, 2, 4, 8, 16, 32, 128, default=32)
-
-        # The soft update coefficient ("Polyak update", between 0 and 1) default
-        # 1 for hard update
-        tau: float = 1.0
-        # tau: float = uniform(0., 1., default=1.0)
-
-        # The discount factor
+        learning_rate: Union[float, Callable] = log_uniform(1e-6, 1e-2, default=3e-4)
+        buffer_size: int = 1_000_000
+        learning_starts: int = 100
+        batch_size: int = 256
+        tau: float = 0.005
         gamma: float = 0.99
-        # gamma: float = uniform(0.9, 0.9999, default=0.99)
-
-        # Update the model every ``train_freq`` steps. Set to `-1` to disable.
-        train_freq: int = 10
-        # train_freq: int = categorical(1, 10, 100, 1_000, 10_000, default=10)
-
-        # How many gradient steps to do after each rollout (see ``train_freq``
-        # and ``n_episodes_rollout``) Set to ``-1`` means to do as many gradient
-        # steps as steps done in the environment during the rollout.
+        train_freq = 1
         gradient_steps: int = 1
-        # gradient_steps: int = categorical(-1, 1, default=1)
-
-        # Enable a memory efficient variant of the replay buffer at a cost of
-        # more complexity.
-        # See https://github.com/DLR-RM/stable-baselines3/issues/37#issuecomment-637501195
+        # action_noise: Optional[ActionNoise] = None
         optimize_memory_usage: bool = False
-        # Whether to create a second environment that will be used for
-        # evaluating the agent periodically. (Only available when passing string
-        # for the environment)
-        create_eval_env: bool = False
-        # Whether or not to build the network at the creation
-        # of the instance
-        _init_setup_model: bool = True
+        ent_coef: Union[str, float] = "auto"
+        target_update_interval: int = 1
+        target_entropy: Union[str, float] = "auto"
+        use_sde: bool = False
+        sde_sample_freq: int = -1
 
 
 @register_method
 @dataclass
-class SACMethod(StableBaselines3Method):
+class SACMethod(OffPolicyMethod):
     """ Method that uses the SAC model from stable-baselines3. """
 
     Model: ClassVar[Type[SACModel]] = SACModel
@@ -95,108 +58,6 @@ class SACMethod(StableBaselines3Method):
 
     def configure(self, setting: ContinualRLSetting):
         super().configure(setting)
-        # TODO: This is mostly just copied from DQN, there is probably need for a new
-        # OffPolicyMethod class that would contain the code common to both?
-
-        # The default value for the buffer size in the DQN model is WAY too
-        # large, so we re-size it depending on the size of the observations.
-        # NOTE: (issue #156) Only consider the images, not the task labels for these
-        # buffer size calculations (since the task labels might be None and have the
-        # np.object dtype).
-        x_space = setting.observation_space.x
-        flattened_observation_space = flatten_space(x_space)
-        observation_size_bytes = flattened_observation_space.sample().nbytes
-
-        # IF there are more than a few dimensions per observation, then we
-        # should probably reduce the size of the replay buffer according to
-        # the size of the observations.
-        max_buffer_size_bytes = self.max_buffer_size_megabytes * 1024 * 1024
-        max_buffer_length = max_buffer_size_bytes // observation_size_bytes
-
-        if max_buffer_length == 0:
-            raise RuntimeError(
-                f"Couldn't even fit a single observation in the buffer, "
-                f"given the  specified max_buffer_size_megabytes "
-                f"({self.max_buffer_size_megabytes}) and the size of a "
-                f"single observation ({observation_size_bytes} bytes)!"
-            )
-
-        if self.hparams.buffer_size > max_buffer_length:
-            calculated_size_bytes = observation_size_bytes * self.hparams.buffer_size
-            calculated_size_gb = calculated_size_bytes / 1024 ** 3
-            warnings.warn(
-                RuntimeWarning(
-                    f"The selected buffer size ({self.hparams.buffer_size} is "
-                    f"too large! (It would take roughly around "
-                    f"{calculated_size_gb:.3f}Gb to hold  many observations alone! "
-                    f"The buffer size will be capped at {max_buffer_length} "
-                    f"entries."
-                )
-            )
-
-            self.hparams.buffer_size = int(max_buffer_length)
-
-        # NOTE: Need to change some attributes depending on the maximal number of steps
-        # in the environment allowed in the given Setting.
-        if setting.max_steps:
-            logger.info(
-                f"Total training steps are limited to {setting.steps_per_task} steps "
-                f"per task, {setting.max_steps} steps in total."
-            )
-            ten_percent_of_step_budget = setting.steps_per_phase // 10
-
-            if self.hparams.buffer_size > ten_percent_of_step_budget:
-                warnings.warn(
-                    RuntimeWarning(
-                        "Reducing max buffer size to ten percent of the step budget."
-                    )
-                )
-                self.hparams.buffer_size = ten_percent_of_step_budget
-
-            if self.hparams.learning_starts > ten_percent_of_step_budget:
-                logger.info(
-                    f"The model was originally going to use the first "
-                    f"{self.hparams.learning_starts} steps for pure random "
-                    f"exploration, but the setting has a max number of steps set to "
-                    f"{setting.max_steps}, therefore we will limit the number of "
-                    f"exploration steps to 10% of that 'step budget' = "
-                    f"{ten_percent_of_step_budget} steps."
-                )
-                self.hparams.learning_starts = ten_percent_of_step_budget
-                if self.hparams.train_freq != -1:
-                    # Update the model at least 2 times during each task, and at most
-                    # once per step.
-                    self.hparams.train_freq = min(
-                        self.hparams.train_freq, int(0.5 * ten_percent_of_step_budget),
-                    )
-                    self.hparams.train_freq = max(self.hparams.train_freq, 1)
-
-                logger.info(f"Training frequency: {self.hparams.train_freq}")
-
-        logger.info(f"Will use a Replay buffer of size {self.hparams.buffer_size}.")
-
-        if setting.steps_per_phase:
-            assert (
-                isinstance(self.hparams.train_freq, int)
-                or self.hparams.train_freq[1] == "steps"
-            ), "Need the train freq units to be steps for now."
-
-            # NOTE: We limit the number of training steps per task, such that we never
-            # attempt to fill the buffer using more samples than the environment allows.
-            if self.hparams.train_freq > setting.steps_per_phase:
-                self.hparams.n_steps = math.ceil(0.1 * setting.steps_per_phase)
-                logger.info(
-                    f"Capping the n_steps to 10% of step budget length: "
-                    f"{self.hparams.n_steps}"
-                )
-
-            self.train_steps_per_task = min(
-                self.train_steps_per_task,
-                setting.steps_per_phase - self.hparams.train_freq - 1,
-            )
-            logger.info(
-                f"Limitting training steps per task to {self.train_steps_per_task}"
-            )
 
     def create_model(self, train_env: gym.Env, valid_env: gym.Env) -> SACModel:
         return self.Model(env=train_env, **self.hparams.to_dict())

--- a/sequoia/methods/stable_baselines3_methods/sac.py
+++ b/sequoia/methods/stable_baselines3_methods/sac.py
@@ -2,35 +2,201 @@
 settings in the tree.
 """
 
+import math
+import warnings
 from dataclasses import dataclass
-from typing import ClassVar, Optional, Type
+from typing import Callable, ClassVar, Optional, Type, Union
 
 import gym
 from gym import spaces
+from gym.spaces.utils import flatten_space
 from simple_parsing import mutable_field
 from stable_baselines3.sac import SAC
 
+from sequoia.common.hparams import log_uniform, uniform
 from sequoia.methods import register_method
 from sequoia.methods.stable_baselines3_methods.base import (
-    SB3BaseHParams, StableBaselines3Method)
+    SB3BaseHParams,
+    StableBaselines3Method,
+)
 from sequoia.settings.active import ContinualRLSetting
+from sequoia.utils.logging_utils import get_logger
+
+
+logger = get_logger(__file__)
+
 
 class SACModel(SAC):
     """ Customized version of the SAC model from stable-baselines-3. """
+
     @dataclass
     class HParams(SB3BaseHParams):
         """ Hyper-parameters of the SAC Model. """
+
         # TODO: Create the fields from the SAC constructor arguments.
+        # The learning rate, it can be a function of the current progress (from
+        # 1 to 0)
+        learning_rate: Union[float, Callable] = log_uniform(1e-6, 1e-2, default=1e-4)
+        # size of the replay buffer
+        buffer_size: int = uniform(100, 10_000_000, default=1_000_000)
+        # How many steps of the model to collect transitions for before learning
+        # starts.
+        learning_starts: int = 50_000
+        # learning_starts: int = uniform(1_000, 100_000, default=50_000)
+
+        # Minibatch size for each gradient update
+        batch_size: Optional[int] = 32
+        # batch_size: Optional[int] = categorical(1, 2, 4, 8, 16, 32, 128, default=32)
+
+        # The soft update coefficient ("Polyak update", between 0 and 1) default
+        # 1 for hard update
+        tau: float = 1.0
+        # tau: float = uniform(0., 1., default=1.0)
+
+        # The discount factor
+        gamma: float = 0.99
+        # gamma: float = uniform(0.9, 0.9999, default=0.99)
+
+        # Update the model every ``train_freq`` steps. Set to `-1` to disable.
+        train_freq: int = 10
+        # train_freq: int = categorical(1, 10, 100, 1_000, 10_000, default=10)
+
+        # How many gradient steps to do after each rollout (see ``train_freq``
+        # and ``n_episodes_rollout``) Set to ``-1`` means to do as many gradient
+        # steps as steps done in the environment during the rollout.
+        gradient_steps: int = 1
+        # gradient_steps: int = categorical(-1, 1, default=1)
+
+        # Enable a memory efficient variant of the replay buffer at a cost of
+        # more complexity.
+        # See https://github.com/DLR-RM/stable-baselines3/issues/37#issuecomment-637501195
+        optimize_memory_usage: bool = False
+        # Whether to create a second environment that will be used for
+        # evaluating the agent periodically. (Only available when passing string
+        # for the environment)
+        create_eval_env: bool = False
+        # Whether or not to build the network at the creation
+        # of the instance
+        _init_setup_model: bool = True
 
 
 @register_method
+@dataclass
 class SACMethod(StableBaselines3Method):
     """ Method that uses the SAC model from stable-baselines3. """
+
     Model: ClassVar[Type[SACModel]] = SACModel
+
+    # Hyper-parameters of the SAC model.
     hparams: SACModel.HParams = mutable_field(SACModel.HParams)
 
+    # Approximate limit on the size of the replay buffer, in megabytes.
+    max_buffer_size_megabytes: float = 2_048.0
+
     def configure(self, setting: ContinualRLSetting):
-        super().configure(setting=setting)
+        super().configure(setting)
+        # TODO: This is mostly just copied from DQN, there is probably need for a new
+        # OffPolicyMethod class that would contain the code common to both?
+
+        # The default value for the buffer size in the DQN model is WAY too
+        # large, so we re-size it depending on the size of the observations.
+        # NOTE: (issue #156) Only consider the images, not the task labels for these
+        # buffer size calculations (since the task labels might be None and have the
+        # np.object dtype).
+        x_space = setting.observation_space.x
+        flattened_observation_space = flatten_space(x_space)
+        observation_size_bytes = flattened_observation_space.sample().nbytes
+
+        # IF there are more than a few dimensions per observation, then we
+        # should probably reduce the size of the replay buffer according to
+        # the size of the observations.
+        max_buffer_size_bytes = self.max_buffer_size_megabytes * 1024 * 1024
+        max_buffer_length = max_buffer_size_bytes // observation_size_bytes
+
+        if max_buffer_length == 0:
+            raise RuntimeError(
+                f"Couldn't even fit a single observation in the buffer, "
+                f"given the  specified max_buffer_size_megabytes "
+                f"({self.max_buffer_size_megabytes}) and the size of a "
+                f"single observation ({observation_size_bytes} bytes)!"
+            )
+
+        if self.hparams.buffer_size > max_buffer_length:
+            calculated_size_bytes = observation_size_bytes * self.hparams.buffer_size
+            calculated_size_gb = calculated_size_bytes / 1024 ** 3
+            warnings.warn(
+                RuntimeWarning(
+                    f"The selected buffer size ({self.hparams.buffer_size} is "
+                    f"too large! (It would take roughly around "
+                    f"{calculated_size_gb:.3f}Gb to hold  many observations alone! "
+                    f"The buffer size will be capped at {max_buffer_length} "
+                    f"entries."
+                )
+            )
+
+            self.hparams.buffer_size = int(max_buffer_length)
+
+        # NOTE: Need to change some attributes depending on the maximal number of steps
+        # in the environment allowed in the given Setting.
+        if setting.max_steps:
+            logger.info(
+                f"Total training steps are limited to {setting.steps_per_task} steps "
+                f"per task, {setting.max_steps} steps in total."
+            )
+            ten_percent_of_step_budget = setting.steps_per_phase // 10
+
+            if self.hparams.buffer_size > ten_percent_of_step_budget:
+                warnings.warn(
+                    RuntimeWarning(
+                        "Reducing max buffer size to ten percent of the step budget."
+                    )
+                )
+                self.hparams.buffer_size = ten_percent_of_step_budget
+
+            if self.hparams.learning_starts > ten_percent_of_step_budget:
+                logger.info(
+                    f"The model was originally going to use the first "
+                    f"{self.hparams.learning_starts} steps for pure random "
+                    f"exploration, but the setting has a max number of steps set to "
+                    f"{setting.max_steps}, therefore we will limit the number of "
+                    f"exploration steps to 10% of that 'step budget' = "
+                    f"{ten_percent_of_step_budget} steps."
+                )
+                self.hparams.learning_starts = ten_percent_of_step_budget
+                if self.hparams.train_freq != -1:
+                    # Update the model at least 2 times during each task, and at most
+                    # once per step.
+                    self.hparams.train_freq = min(
+                        self.hparams.train_freq, int(0.5 * ten_percent_of_step_budget),
+                    )
+                    self.hparams.train_freq = max(self.hparams.train_freq, 1)
+
+                logger.info(f"Training frequency: {self.hparams.train_freq}")
+
+        logger.info(f"Will use a Replay buffer of size {self.hparams.buffer_size}.")
+
+        if setting.steps_per_phase:
+            assert (
+                isinstance(self.hparams.train_freq, int)
+                or self.hparams.train_freq[1] == "steps"
+            ), "Need the train freq units to be steps for now."
+
+            # NOTE: We limit the number of training steps per task, such that we never
+            # attempt to fill the buffer using more samples than the environment allows.
+            if self.hparams.train_freq > setting.steps_per_phase:
+                self.hparams.n_steps = math.ceil(0.1 * setting.steps_per_phase)
+                logger.info(
+                    f"Capping the n_steps to 10% of step budget length: "
+                    f"{self.hparams.n_steps}"
+                )
+
+            self.train_steps_per_task = min(
+                self.train_steps_per_task,
+                setting.steps_per_phase - self.hparams.train_freq - 1,
+            )
+            logger.info(
+                f"Limitting training steps per task to {self.train_steps_per_task}"
+            )
 
     def create_model(self, train_env: gym.Env, valid_env: gym.Env) -> SACModel:
         return self.Model(env=train_env, **self.hparams.to_dict())
@@ -38,12 +204,11 @@ class SACMethod(StableBaselines3Method):
     def fit(self, train_env: gym.Env, valid_env: gym.Env):
         super().fit(train_env=train_env, valid_env=valid_env)
 
-    def get_actions(self,
-                    observations: ContinualRLSetting.Observations,
-                    action_space: spaces.Space) -> ContinualRLSetting.Actions:
+    def get_actions(
+        self, observations: ContinualRLSetting.Observations, action_space: spaces.Space
+    ) -> ContinualRLSetting.Actions:
         return super().get_actions(
-            observations=observations,
-            action_space=action_space,
+            observations=observations, action_space=action_space,
         )
 
     def on_task_switch(self, task_id: Optional[int]) -> None:
@@ -55,6 +220,7 @@ class SACMethod(StableBaselines3Method):
 
         todo: use this to customize how your method handles task transitions.
         """
+
 
 if __name__ == "__main__":
     results = SACMethod.main()

--- a/sequoia/methods/stable_baselines3_methods/sac_test.py
+++ b/sequoia/methods/stable_baselines3_methods/sac_test.py
@@ -11,6 +11,7 @@ from .sac import SACMethod
 from typing import Type
 
 
+@pytest.mark.timeout(120)
 @pytest.mark.parametrize(
     "Setting", [ContinualRLSetting, IncrementalRLSetting, TaskIncrementalRLSetting]
 )

--- a/sequoia/methods/stable_baselines3_methods/sac_test.py
+++ b/sequoia/methods/stable_baselines3_methods/sac_test.py
@@ -1,45 +1,30 @@
 import pytest
 from sequoia.common.config import Config
-from sequoia.conftest import monsterkong_required
 from sequoia.settings.active import (
     ContinualRLSetting,
     IncrementalRLSetting,
     TaskIncrementalRLSetting,
 )
-
+from sequoia.settings import Setting
 
 from .sac import SACMethod
-import pytest
+from typing import Type
 
 
-@pytest.mark.xfail(reason="needs continuous action space")
-def test_cartpole_state():
+@pytest.mark.parametrize(
+    "Setting", [ContinualRLSetting, IncrementalRLSetting, TaskIncrementalRLSetting]
+)
+@pytest.mark.parametrize("observe_state", [True, False])
+def test_continuous_mountaincar_state(Setting: Type[Setting], observe_state: bool):
     method = SACMethod()
-    setting = IncrementalRLSetting(
-        dataset="cartpole",
+    setting = Setting(
+        dataset="MountainCarContinuous-v0",
         observe_state_directly=True,
         nb_tasks=2,
         steps_per_task=1_000,
         test_steps_per_task=1_000,
     )
-    results: IncrementalRLSetting.Results = setting.apply(
+    results: ContinualRLSetting.Results = setting.apply(
         method, config=Config(debug=True)
     )
     print(results.summary())
-
-
-@pytest.mark.xfail(reason="needs continuous action space")
-@monsterkong_required
-def test_monsterkong():
-    method = SACMethod()
-    setting = IncrementalRLSetting(
-        dataset="monsterkong",
-        nb_tasks=2,
-        steps_per_task=1_000,
-        test_steps_per_task=1_000,
-    )
-    results: IncrementalRLSetting.Results = setting.apply(
-        method, config=Config(debug=True)
-    )
-    print(results.summary())
-

--- a/sequoia/methods/stable_baselines3_methods/sac_test.py
+++ b/sequoia/methods/stable_baselines3_methods/sac_test.py
@@ -6,17 +6,21 @@ from sequoia.settings.active import (
     TaskIncrementalRLSetting,
 )
 from sequoia.settings import Setting
+from sequoia.conftest import slow
 
 from .sac import SACMethod
 from typing import Type
 
 
+# TODO: Look into why SAC is so slow, there's probably a parameter which isn't being set
+# properly.
+@slow
 @pytest.mark.timeout(120)
 @pytest.mark.parametrize(
     "Setting", [ContinualRLSetting, IncrementalRLSetting, TaskIncrementalRLSetting]
 )
 @pytest.mark.parametrize("observe_state", [True, False])
-def test_continuous_mountaincar_state(Setting: Type[Setting], observe_state: bool):
+def test_continuous_mountaincar(Setting: Type[Setting], observe_state: bool):
     method = SACMethod()
     setting = Setting(
         dataset="MountainCarContinuous-v0",

--- a/sequoia/methods/stable_baselines3_methods/td3.py
+++ b/sequoia/methods/stable_baselines3_methods/td3.py
@@ -1,34 +1,58 @@
 """ TODO: Implement and test DDPG. """
 from dataclasses import dataclass
-from typing import ClassVar, Optional, Type
+from typing import Callable, ClassVar, Optional, Type, Union
 
 import gym
 from gym import spaces
 from simple_parsing import mutable_field
 from stable_baselines3.td3 import TD3
+from stable_baselines3.common.off_policy_algorithm import TrainFreq
 
+from sequoia.common.hparams import log_uniform
 from sequoia.methods import register_method
-from sequoia.methods.stable_baselines3_methods.base import (
-    SB3BaseHParams, StableBaselines3Method)
 from sequoia.settings.active import ContinualRLSetting
+from sequoia.utils.logging_utils import get_logger
+from .off_policy_method import OffPolicyMethod, OffPolicyModel
+
+logger = get_logger(__file__)
 
 
-class TD3Model(TD3):
+class TD3Model(TD3, OffPolicyModel):
     @dataclass
-    class HParams(SB3BaseHParams):
+    class HParams(OffPolicyModel.HParams):
         """ Hyper-parameters of the TD3 model. """
-        # TODO: Create the fields from the TD3 constructor arguments.
+        # TODO: Add HParams specific to TD3 here, if any, and also check that the
+        # default values are correct.
 
+        # The learning rate, it can be a function of the current progress (from
+        # 1 to 0)
+        learning_rate: Union[float, Callable] = log_uniform(1e-6, 1e-2, default=1e-3)
+
+        # Minibatch size for each gradient update
+        batch_size: int = 100
+        # batch_size: int = categorical(1, 2, 4, 8, 16, 32, 128, default=32)
+
+        train_freq: TrainFreq = (1, "episode")
+
+        # How many gradient steps to do after each rollout (see ``train_freq``
+        # and ``n_episodes_rollout``) Set to ``-1`` means to do as many gradient
+        # steps as steps done in the environment during the rollout.
+        gradient_steps: int = -1
+        # gradient_steps: int = categorical(1, -1, default=1)
 
 @register_method
 @dataclass
-class TD3Method(StableBaselines3Method):
+class TD3Method(OffPolicyMethod):
     """ Method that uses the TD3 model from stable-baselines3. """
+
     Model: ClassVar[Type[TD3Model]] = TD3Model
     hparams: TD3Model.HParams = mutable_field(TD3Model.HParams)
 
+    # Approximate limit on the size of the replay buffer, in megabytes.
+    max_buffer_size_megabytes: float = 2_048.0
+
     def configure(self, setting: ContinualRLSetting):
-        super().configure(setting=setting)
+        super().configure(setting)
 
     def create_model(self, train_env: gym.Env, valid_env: gym.Env) -> TD3Model:
         return self.Model(env=train_env, **self.hparams.to_dict())
@@ -36,12 +60,11 @@ class TD3Method(StableBaselines3Method):
     def fit(self, train_env: gym.Env, valid_env: gym.Env):
         super().fit(train_env=train_env, valid_env=valid_env)
 
-    def get_actions(self,
-                    observations: ContinualRLSetting.Observations,
-                    action_space: spaces.Space) -> ContinualRLSetting.Actions:
+    def get_actions(
+        self, observations: ContinualRLSetting.Observations, action_space: spaces.Space
+    ) -> ContinualRLSetting.Actions:
         return super().get_actions(
-            observations=observations,
-            action_space=action_space,
+            observations=observations, action_space=action_space,
         )
 
     def on_task_switch(self, task_id: Optional[int]) -> None:

--- a/sequoia/methods/stable_baselines3_methods/td3_test.py
+++ b/sequoia/methods/stable_baselines3_methods/td3_test.py
@@ -1,43 +1,30 @@
 import pytest
 from sequoia.common.config import Config
-from sequoia.conftest import monsterkong_required
 from sequoia.settings.active import (
     ContinualRLSetting,
     IncrementalRLSetting,
     TaskIncrementalRLSetting,
 )
+from sequoia.settings import Setting
 
 from .td3 import TD3Method
+from typing import Type
 
 
-@pytest.mark.xfail(reason="needs continuous action space.")
-def test_cartpole_state():
+@pytest.mark.parametrize(
+    "Setting", [ContinualRLSetting, IncrementalRLSetting, TaskIncrementalRLSetting]
+)
+@pytest.mark.parametrize("observe_state", [True, False])
+def test_continuous_mountaincar_state(Setting: Type[Setting], observe_state: bool):
     method = TD3Method()
-    setting = IncrementalRLSetting(
-        dataset="cartpole",
+    setting = Setting(
+        dataset="MountainCarContinuous-v0",
         observe_state_directly=True,
         nb_tasks=2,
         steps_per_task=1_000,
         test_steps_per_task=1_000,
     )
-    results: IncrementalRLSetting.Results = setting.apply(
+    results: ContinualRLSetting.Results = setting.apply(
         method, config=Config(debug=True)
     )
     print(results.summary())
-
-
-@pytest.mark.xfail(reason="needs continuous action spaces.")
-@monsterkong_required
-def test_monsterkong():
-    method = TD3Method()
-    setting = IncrementalRLSetting(
-        dataset="monsterkong",
-        nb_tasks=2,
-        steps_per_task=1_000,
-        test_steps_per_task=1_000,
-    )
-    results: IncrementalRLSetting.Results = setting.apply(
-        method, config=Config(debug=True)
-    )
-    print(results.summary())
-

--- a/sequoia/methods/stable_baselines3_methods/td3_test.py
+++ b/sequoia/methods/stable_baselines3_methods/td3_test.py
@@ -15,7 +15,7 @@ from typing import Type
     "Setting", [ContinualRLSetting, IncrementalRLSetting, TaskIncrementalRLSetting]
 )
 @pytest.mark.parametrize("observe_state", [True, False])
-def test_continuous_mountaincar_state(Setting: Type[Setting], observe_state: bool):
+def test_continuous_mountaincar(Setting: Type[Setting], observe_state: bool):
     method = TD3Method()
     setting = Setting(
         dataset="MountainCarContinuous-v0",

--- a/sequoia/settings/active/continual/continual_rl_setting_test.py
+++ b/sequoia/settings/active/continual/continual_rl_setting_test.py
@@ -17,21 +17,25 @@ from .continual_rl_setting import ContinualRLSetting
 
 
 def test_task_schedule_is_used():
-    # TODO: Figure out a way to test that the tasks are switching over time.
+    """
+    Test that the tasks are switching over time.
+    """
     setting = ContinualRLSetting(
-        dataset="CartPole-v0", max_steps=100, steps_per_task=10, nb_tasks=10
+        dataset="CartPole-v0", max_steps=100, steps_per_task=50, nb_tasks=2
     )
     env = setting.train_dataloader(batch_size=None)
 
     starting_length = env.length
     assert starting_length == 0.5
 
-    observations = env.reset()
+    _ = env.reset()
     lengths: List[float] = []
-    for i in range(100):
+    for i in range(setting.steps_per_phase):
         obs, reward, done, info = env.step(env.action_space.sample())
-        if done:
+        if done and i != setting.steps_per_phase - 1:
+            # NOTE: Don't reset on the last step
             env.reset()
+        # Get the length of the pole from the environment.
         length = env.length
         lengths.append(length)
     assert not all(length == starting_length for length in lengths)

--- a/sequoia/settings/active/continual/incremental/task_incremental/task_incremental_rl_setting_test.py
+++ b/sequoia/settings/active/continual/incremental/task_incremental/task_incremental_rl_setting_test.py
@@ -1,39 +1,41 @@
-from .task_incremental_rl_setting import TaskIncrementalRLSetting
+from typing import List
+
 from sequoia.common.gym_wrappers import MultiTaskEnvironment
+
+from .task_incremental_rl_setting import TaskIncrementalRLSetting
 
 
 def test_task_schedule_is_used():
-    # TODO: Figure out a way to test that the tasks are switching over time.
+    """ Test that the tasks are switching over time. """
     setting = TaskIncrementalRLSetting(
-        dataset="CartPole-v0",
-        max_steps = 100,
-        steps_per_task=50,
-        nb_tasks=2,
+        dataset="CartPole-v0", max_steps=100, steps_per_task=50, nb_tasks=2,
     )
-    
+
     default_length = 0.5
-    
-    
+
     for task_id in range(2):
         setting.current_task_id = task_id
-        
+
         env = setting.train_dataloader(batch_size=None)
         env: MultiTaskEnvironment
         assert len(setting.train_task_schedule) == 2
         assert len(setting.valid_task_schedule) == 2
         assert len(setting.test_task_schedule) == 2
-        
+
         starting_length = env.length
-        
-        observations = env.reset()
+
+        _ = env.reset()
         lengths: List[float] = []
-        for i in range(setting.steps_per_task):
+        for i in range(setting.steps_per_phase):
             obs, reward, done, info = env.step(env.action_space.sample())
-            if done:
+            # NOTE: If we're done on the last step, we can't reset, since that would go
+            # over the step budget.
+            if done and i != setting.steps_per_phase - 1:
                 env.reset()
+            # Get the length of the pole from the environment.    
             length = env.length
             lengths.append(length)
-        
+
         if task_id == 0:
             assert starting_length == default_length
             assert all(length == default_length for length in lengths)
@@ -43,5 +45,5 @@ def test_task_schedule_is_used():
             assert starting_length != default_length
             # The length shouldn't be changing over time.
             assert all(length == starting_length for length in lengths)
-                
+
     # assert False, (lengths[:2], lengths[-2:])

--- a/sequoia/settings/active/continual/rl_results.py
+++ b/sequoia/settings/active/continual/rl_results.py
@@ -48,26 +48,3 @@ class RLResults(IncrementalResults[EpisodeMetrics]):
         axes.set_ylim(0, 1.0)
         autolabel(axes, rects)
         return figure
-
-    @property
-    def cl_score(self) -> float:
-        """ CL Score, as a weigted sum of three objectives:
-        - The average final performance over all tasks
-        - The average 'online' performance over all tasks
-        - Runtime
-
-        TODO: @optimass Determine the weights for each factor.
-
-        Returns
-        -------
-        float
-            [description]
-        """
-        # TODO: Determine the function to use to get a runtime score between 0 and 1.
-        # TODO: Add a property on the Results, which is based on the environment used.
-        score = (
-            +0.25 * self._online_performance_score()
-            + 0.50 * self._final_performance_score()
-            + 0.25 * self._runtime_score()
-        )
-        return score

--- a/sequoia/settings/assumptions/incremental.py
+++ b/sequoia/settings/assumptions/incremental.py
@@ -416,16 +416,26 @@ class IncrementalSetting(ContinualSetting):
                 # BUG: Need to pass an action space that actually reflects the batch
                 # size, even for the last batch!
 
+                # BUG: This doesn't work if the env isn't batched.
                 action_space = test_env.action_space
-                # Check for a potential mismatch between the batch size in the obs and
-                # the batch size in the action space.
-                if getattr(test_env.action_space, "shape", None):
-                    assert obs.x.shape, "x should also have a shape (i.e. not an int)"
-                    obs_batch_size = obs.x.shape[0]
-                    action_space_batch_size = test_env.action_space.shape[0]
-                    if obs_batch_size != action_space_batch_size:
-                        single_action_space = test_env.single_action_space
-                        action_space = batch_space(single_action_space, obs_batch_size)
+                batch_size = getattr(test_env, "num_envs", getattr(test_env, "batch_size", 0))
+                env_is_batched = batch_size is not None and batch_size >= 1
+                if env_is_batched:
+                    # NOTE: Need to pass an action space that actually reflects the batch
+                    # size, even for the last batch!
+                    obs_batch_size = obs.x.shape[0] if obs.x.shape else None
+                    action_space_batch_size = (
+                        test_env.action_space.shape[0]
+                        if test_env.action_space.shape
+                        else None
+                    )
+                    if (
+                        obs_batch_size is not None
+                        and obs_batch_size != action_space_batch_size
+                    ):
+                        action_space = batch_space(
+                            test_env.single_action_space, obs_batch_size
+                        )
 
                 action = method.get_actions(obs, action_space)
 

--- a/sequoia/settings/assumptions/incremental.py
+++ b/sequoia/settings/assumptions/incremental.py
@@ -200,7 +200,7 @@ class IncrementalSetting(ContinualSetting):
         # TODO: Fix this up, need to set the '_objective_scaling_factor' to a different
         # value depending on the 'dataset' / environment.
         results._objective_scaling_factor = self._get_objective_scaling_factor()
-        
+
         if self.wandb:
             # Init wandb, and then log the setting's options.
             self.wandb_run = self.setup_wandb(method)

--- a/sequoia/settings/assumptions/incremental_results.py
+++ b/sequoia/settings/assumptions/incremental_results.py
@@ -179,25 +179,25 @@ class IncrementalResults(List[TaskSequenceResults[MetricType]]):
         )
 
     def _online_performance_score(self) -> float:
-        # Function that takes the 'objective' of the Metrics from the average
-        # online performance, and returns a normalized float score between 0 and 1.
-        # TODO: Use the 'average of the averages' instead of the "true", sample-aware
-        # average.
+        """Function that takes the 'objective' of the Metrics from the average online
+        performance, and returns a normalized float score between 0 and 1.
+        """
         objectives: List[float] = [
             task_online_metric.objective
             for task_online_metric in self.online_performance_metrics
         ]
         return self._objective_scaling_factor * np.mean(objectives)
-        # return type(self).objective_scaling_factor * self.average_online_performance.objective
+        # return self._objective_scaling_factor * self.average_online_performance.objective
 
     def _final_performance_score(self) -> float:
-        # TODO: function that takes the 'objective' of the Metrics from the average
-        # final performance, and returns a normalized float score between 0 and 1.
+        """ Function that takes the 'objective' of the Metrics from the average
+        final performance, and returns a normalized float score between 0 and 1.
+        """
         objectives: List[float] = [
             task_metric.objective for task_metric in self.final_performance_metrics
         ]
         return self._objective_scaling_factor * np.mean(objectives)
-        # return type(self).objective_scaling_factor * self.average_final_performance.objective
+        # return self._objective_scaling_factor * self.average_final_performance.objective
 
     @property
     def objective(self) -> float:

--- a/sequoia/settings/passive/cl/class_incremental_setting_test.py
+++ b/sequoia/settings/passive/cl/class_incremental_setting_test.py
@@ -6,7 +6,7 @@ from gym.spaces import Discrete, Space
 from sequoia.common.gym_wrappers.convert_tensors import has_tensor_support
 from sequoia.common.spaces import Sparse
 from sequoia.methods import RandomBaselineMethod
-from sequoia.conftest import xfail_param
+from sequoia.conftest import xfail_param, skip_param
 
 from .class_incremental_setting import (
     ClassIncrementalSetting,
@@ -15,12 +15,12 @@ from .class_incremental_setting import (
 )
 
 # TODO: Add a fixture that specifies a data folder common to all tests.
-
 @pytest.mark.parametrize(
     "dataset_name",
     [
         "mnist",
-        "synbols",
+        # "synbols",
+        skip_param("synbols", reason="Causes tests to hang for some reason?"),
         "cifar10",
         "cifar100",
         "fashionmnist",

--- a/tests/examples/quick_demo_test.py
+++ b/tests/examples/quick_demo_test.py
@@ -47,5 +47,5 @@ def test_quick_demo(monkeypatch):
     assert 0.48 <= results.final_performance_metrics[0].accuracy <= 0.55
     assert 0.48 <= results.final_performance_metrics[1].accuracy <= 0.70
     assert 0.60 <= results.final_performance_metrics[2].accuracy <= 1.00
-    assert 0.75 <= results.final_performance_metrics[3].accuracy <= 1.00
+    assert 0.70 <= results.final_performance_metrics[3].accuracy <= 1.00
     assert 0.99 <= results.final_performance_metrics[4].accuracy <= 1.00


### PR DESCRIPTION
- Fixes #195 
- Fixes an error in the calculation of the CL score in the RL Track
- Adds the `OnPolicyMethod` and `OffPolicyMethod`, which contain the "tweaks" to be made to the corresponding base classes in SB3.
- Adds test to ensure that SB3 **Methods use the same default values for hparams as their corresponding algos in SB3**!

The class hierarchy for the SB3 methods now looks like this:
- StableBaselines3Method
    - OnPolicyMethod
        - PPOMethod
        - A2CMethod
    - OffPolicyMethod
        - DQNMethod
        - DDPGMethod  (requires continuous action space) 
        - SACMethod  (requires continuous action space)
        - TD3Method  (requires continuous action space)
