### PR TITLE
Add CTrL Benchmark Support

### DIFF
--- a/sequoia/common/spaces/image.py
+++ b/sequoia/common/spaces/image.py
@@ -12,6 +12,16 @@ from .tensor_spaces import TensorBox
 from .space import Space, T
 
 
+def could_become_image(space: spaces.Space) -> bool:
+    if not isinstance(space, spaces.Box):
+        return False
+    shape = space.shape
+    return len(shape) == 3 and (
+        shape[0] == shape[1] and shape[2] in {1, 3} or
+        shape[1] == shape[2] and shape[0] in {1, 3}
+    )
+
+
 class Image(spaces.Box, Space[T]):
     """ Subclass of `gym.spaces.Box` for images.
 

--- a/sequoia/settings/sl/continual/environment.py
+++ b/sequoia/settings/sl/continual/environment.py
@@ -109,6 +109,8 @@ base_reward_spaces: Dict[str, Space] = {
 }
 
 
+
+
 def split_batch(
     batch: Tuple[Tensor, ...],
     hide_task_labels: bool,

--- a/sequoia/settings/sl/continual/envs.py
+++ b/sequoia/settings/sl/continual/envs.py
@@ -1,0 +1,279 @@
+""" Utility functions for determining the observation space for a given SL dataset.
+"""
+import itertools
+import warnings
+from functools import partial
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
+
+import gym
+import numpy as np
+from continuum.datasets import (
+    CIFAR10,
+    CIFAR100,
+    EMNIST,
+    KMNIST,
+    MNIST,
+    QMNIST,
+    CIFARFellowship,
+    Core50,
+    Core50v2_79,
+    Core50v2_196,
+    Core50v2_391,
+    FashionMNIST,
+    ImageNet100,
+    ImageNet1000,
+    MNISTFellowship,
+    Synbols,
+    _ContinuumDataset,
+)
+from continuum.tasks import TaskSet
+from gym import Space, spaces
+from torch import Tensor
+from torch.nn import functional as F
+from torch.utils.data import DataLoader, Dataset, IterableDataset, Subset, ConcatDataset
+from sequoia.common.spaces.image import could_become_image
+from sequoia.common.spaces import TensorBox, TensorDiscrete
+from sequoia.common.gym_wrappers.batch_env.tile_images import tile_images
+from sequoia.common.gym_wrappers.convert_tensors import (
+    add_tensor_support as tensor_space,
+)
+from torch.utils.data import TensorDataset
+from sequoia.common.spaces import ImageTensorSpace, TypedDictSpace
+from sequoia.common.transforms import Transforms
+from sequoia.settings.sl.environment import PassiveEnvironment
+from sequoia.utils.logging_utils import get_logger
+
+from .objects import (
+    Actions,
+    ActionType,
+    Observations,
+    ObservationType,
+    Rewards,
+    RewardType,
+)
+
+logger = get_logger(__file__)
+
+
+base_observation_spaces: Dict[str, Space] = {
+    dataset_class.__name__.lower(): space
+    for dataset_class, space in {
+        MNIST: ImageTensorSpace(0, 1, shape=(1, 28, 28)),
+        FashionMNIST: ImageTensorSpace(0, 1, shape=(1, 28, 28)),
+        KMNIST: ImageTensorSpace(0, 1, shape=(1, 28, 28)),
+        EMNIST: ImageTensorSpace(0, 1, shape=(1, 28, 28)),
+        QMNIST: ImageTensorSpace(0, 1, shape=(1, 28, 28)),
+        MNISTFellowship: ImageTensorSpace(0, 1, shape=(1, 28, 28)),
+        # TODO: Determine the true bounds on the image values in cifar10.
+        # Appears to be  ~= [-2.5, 2.5]
+        CIFAR10: ImageTensorSpace(-np.inf, np.inf, shape=(3, 32, 32)),
+        CIFAR100: ImageTensorSpace(-np.inf, np.inf, shape=(3, 32, 32)),
+        CIFARFellowship: ImageTensorSpace(-np.inf, np.inf, shape=(3, 32, 32)),
+        ImageNet100: ImageTensorSpace(0, 1, shape=(224, 224, 3)),
+        ImageNet1000: ImageTensorSpace(0, 1, shape=(224, 224, 3)),
+        Core50: ImageTensorSpace(0, 1, shape=(224, 224, 3)),
+        Core50v2_79: ImageTensorSpace(0, 1, shape=(224, 224, 3)),
+        Core50v2_196: ImageTensorSpace(0, 1, shape=(224, 224, 3)),
+        Core50v2_391: ImageTensorSpace(0, 1, shape=(224, 224, 3)),
+        Synbols: ImageTensorSpace(0, 1, shape=(3, 32, 32)),
+    }.items()
+}
+
+
+base_action_spaces: Dict[str, Space] = {
+    dataset_class.__name__.lower(): space
+    for dataset_class, space in {
+        MNIST: spaces.Discrete(10),
+        FashionMNIST: spaces.Discrete(10),
+        KMNIST: spaces.Discrete(10),
+        EMNIST: spaces.Discrete(10),
+        QMNIST: spaces.Discrete(10),
+        MNISTFellowship: spaces.Discrete(30),
+        CIFAR10: spaces.Discrete(10),
+        CIFAR100: spaces.Discrete(100),
+        CIFARFellowship: spaces.Discrete(110),
+        ImageNet100: spaces.Discrete(100),
+        ImageNet1000: spaces.Discrete(1000),
+        Core50: spaces.Discrete(50),
+        Core50v2_79: spaces.Discrete(50),
+        Core50v2_196: spaces.Discrete(50),
+        Core50v2_391: spaces.Discrete(50),
+        Synbols: spaces.Discrete(48),
+    }.items()
+}
+
+
+# NOTE: Since the current SL datasets are image classification, the reward spaces are
+# the same as the action space. But that won't be the case when we add other types of
+# datasets!
+base_reward_spaces: Dict[str, Space] = {
+    dataset_name: action_space
+    for dataset_name, action_space in base_action_spaces.items()
+    if isinstance(action_space, spaces.Discrete)
+}
+
+from functools import singledispatch
+
+@singledispatch
+def get_observation_space(dataset: Any) -> gym.Space:
+    raise NotImplementedError(
+        f"Don't yet have a registered handler to get the observation space of dataset "
+        f"{dataset}."
+    )
+
+
+@get_observation_space.register(Subset)
+def _get_observation_space_for_subset(dataset: Subset) -> gym.Space:
+    # The observations space of a Subset dataset is actually the same as the original
+    # dataset.
+    return get_observation_space(dataset.dataset)
+
+
+@get_observation_space.register(str)
+def _get_observation_space_for_dataset_name(dataset: str) -> gym.Space:
+    if dataset not in base_observation_spaces:
+        raise NotImplementedError(
+            f"Can't yet tell what the 'base' observation space is for dataset "
+            f"{dataset} because it doesn't have an entry in the "
+            f"`base_observation_spaces` dict."
+        )
+    return base_observation_spaces[dataset]
+
+
+@get_observation_space.register(TaskSet)
+def _get_observation_space_for_taskset(dataset: TaskSet) -> gym.Space:
+    assert False, dataset
+    # return get_observation_space(type(dataset).__name__.lower())
+
+
+@get_observation_space.register(TensorDataset)
+def _get_observation_space_for_tensor_dataset(dataset: TensorDataset) -> gym.Space:
+    x = dataset.tensors[0]
+    if not (1 <= len(dataset.tensors) <= 2) or not (2 <= x.dim()):
+        raise NotImplementedError(
+            f"For now, can only handle TensorDatasets with 1 or 2 tensors. (x and y) "
+            f"but dataset {dataset} has {len(dataset.tensors)}!"
+        )
+
+    low = x.min().cpu().item()
+    high = x.max().cpu().item()
+    obs_space = TensorBox(low=low, high=high, shape=x.shape[1:], dtype=x.dtype)
+    if could_become_image(obs_space):
+        obs_space = ImageTensorSpace.wrap(obs_space)
+    return obs_space
+
+
+
+@singledispatch
+def get_action_space(dataset: Any) -> gym.Space:
+    raise NotImplementedError(
+        f"Don't yet have a registered handler to get the action space of dataset "
+        f"{dataset}."
+    )
+
+@get_action_space.register(Subset)
+def _get_action_space_for_subset(dataset: Subset) -> gym.Space:
+    # The actions space of a Subset dataset is actually the same as the original
+    # dataset.
+    return get_action_space(dataset.dataset)
+
+
+@get_action_space.register(str)
+def _get_action_space_for_dataset_name(dataset: str) -> gym.Space:
+    if dataset not in base_action_spaces:
+        raise NotImplementedError(
+            f"Can't yet tell what the 'base' action space is for dataset "
+            f"{dataset} because it doesn't have an entry in the "
+            f"`base_action_spaces` dict."
+        )
+    return base_action_spaces[dataset]
+
+
+@singledispatch
+def get_reward_space(dataset: Any) -> gym.Space:
+    raise NotImplementedError(
+        f"Don't yet have a registered handler to get the reward space of dataset "
+        f"{dataset}."
+    )
+
+
+@get_reward_space.register(Subset)
+def _get_reward_space_for_subset(dataset: Subset) -> gym.Space:
+    # The rewards space of a Subset dataset is *usually* the same as the original
+    # dataset.
+    # TODO: Need to check this though? Maybe we're taking only the indices with a given class
+    return get_reward_space(dataset.dataset)
+
+
+@get_reward_space.register(str)
+def _get_reward_space_for_dataset_name(dataset: str) -> gym.Space:
+    if dataset not in base_reward_spaces:
+        raise NotImplementedError(
+            f"Can't yet tell what the 'base' reward space is for dataset "
+            f"{dataset} because it doesn't have an entry in the "
+            f"`base_reward_spaces` dict."
+        )
+    return base_reward_spaces[dataset]
+
+
+@get_reward_space.register(TensorDataset)
+@get_action_space.register(TensorDataset)
+def get_y_space_for_tensor_dataset(dataset: TensorDataset) -> gym.Space:
+    if len(dataset.tensors) != 2:
+        raise NotImplementedError(
+            f"Only able to detect the action space of TensorDatasets if they have two "
+            f"tensors for now (x and y), but dataset {dataset} has {len(dataset.tensors)}!"
+        )
+    y = dataset.tensors[-1]
+    low = y.min().item()
+    high = y.max().item()
+    y_sample_shape = y.shape[1:]
+
+    if y.dtype.is_floating_point:
+        return TensorBox(low, high, shape=y_sample_shape, dtype=y.dtype)
+
+    # Integer y:
+    if low == 0:
+        n_classes = high + 1
+        return TensorDiscrete(n_classes)
+
+    # TODO: Add a space like DiscreteWithOffset ?
+    return TensorBox(low, high, shape=y_sample_shape, dtype=y.dtype)
+
+@get_action_space.register(list)
+@get_action_space.register(tuple)
+def _get_action_space_for_list_of_datasets(datasets: Sequence[TaskSet]) -> gym.Space:
+    # TODO: IDEA: If given a list of datasets, try to find the 'union' of their spaces.
+    # This is meant to be one potential solution to the case where custom datasets are
+    # passed for each task, like [0, 2), [3, 4], etc.
+    action_spaces = [get_action_space(dataset) for dataset in datasets]
+    if isinstance(action_spaces[0], spaces.Discrete):
+        lows = [0 if isinstance(space, spaces.Discrete) else space.low for space in action_spaces] 
+        highs = [space.n - 1 if isinstance(space, spaces.Discrete) else space.high for space in action_spaces] 
+    
+    if isinstance(reward_spaces[0], spaces.Discrete) and min(lows) == 0:
+        return TensorDiscrete(max(highs)+1)
+
+    raise NotImplementedError(
+        f"Don't yet know how to get the 'union' of the action spaces ({action_spaces}) "
+        f" of datasets {datasets}"
+    )
+
+@get_reward_space.register(list)
+@get_reward_space.register(tuple)
+def _get_reward_space_for_list_of_datasets(datasets: Sequence[TaskSet]) -> gym.Space:
+    # TODO: IDEA: If given a list of datasets, try to find the 'union' of their spaces.
+    # This is meant to be one potential solution to the case where custom datasets are
+    # passed for each task, like [0, 2), [3, 4], etc.
+    reward_spaces = [get_reward_space(dataset) for dataset in datasets]
+    if isinstance(reward_spaces[0], spaces.Discrete):
+        lows = [0 if isinstance(space, spaces.Discrete) else space.low for space in reward_spaces] 
+        highs = [space.n - 1 if isinstance(space, spaces.Discrete) else space.high for space in reward_spaces] 
+    
+    if isinstance(reward_spaces[0], spaces.Discrete) and min(lows) == 0:
+        return TensorDiscrete(max(highs)+1)
+
+    raise NotImplementedError(
+        f"Don't yet know how to get the 'union' of the reward spaces ({reward_spaces}) "
+        f" of datasets {datasets}"
+    )

--- a/sequoia/settings/sl/continual/envs.py
+++ b/sequoia/settings/sl/continual/envs.py
@@ -128,7 +128,7 @@ except ImportError as exc:
     class TaskGenerator: pass
 else:
     CTRL_INSTALLED = True
-    CTRL_STREAMS = ["s_minus", "s_minus", "s_in", "s_out", "s_pl", "s_long"]
+    CTRL_STREAMS = ["s_plus", "s_minus", "s_in", "s_out", "s_pl", "s_long"]
     n_tasks = [5, 5, 5, 5, 4, None]
     CTRL_NB_TASKS = dict(zip(CTRL_STREAMS, n_tasks))
     x_dims = [(3, 32, 32)] * len(CTRL_STREAMS)

--- a/sequoia/settings/sl/continual/setting.py
+++ b/sequoia/settings/sl/continual/setting.py
@@ -42,7 +42,7 @@ from sequoia.settings.base import Method, SettingABC
 from sequoia.settings.sl import SLSetting
 from sequoia.settings.sl.environment import PassiveEnvironment
 from sequoia.settings.sl.wrappers import MeasureSLPerformanceWrapper
-from sequoia.utils.generic_functions import move
+from sequoia.utils.generic_functions import move, concatenate
 from sequoia.utils.logging_utils import get_logger
 from sequoia.utils.utils import flag
 
@@ -643,7 +643,7 @@ class ContinualSLSetting(SLSetting, ContinualAssumption):
         if self.known_task_boundaries_at_train_time:
             return self.train_datasets[self.current_task_id]
         else:
-            return concat(self.train_datasets)
+            return concatenate(self.train_datasets)
 
     def _make_val_dataset(self) -> Dataset:
         if self.smooth_task_boundaries:
@@ -655,7 +655,7 @@ class ContinualSLSetting(SLSetting, ContinualAssumption):
             return shuffle(joined_dataset, seed=self.config.seed)
         if self.known_task_boundaries_at_train_time:
             return self.val_datasets[self.current_task_id]
-        return concat(self.val_datasets)
+        return concatenate(self.val_datasets)
 
     def _make_test_dataset(self) -> Dataset:
         if self.smooth_task_boundaries:
@@ -663,7 +663,7 @@ class ContinualSLSetting(SLSetting, ContinualAssumption):
                 self.test_datasets, seed=self.config.seed
             )
         else:
-            return concat(self.test_datasets)
+            return concatenate(self.test_datasets)
 
     def make_dataset(
         self, data_dir: Path, download: bool = True, train: bool = True, **kwargs
@@ -692,7 +692,7 @@ class ContinualSLSetting(SLSetting, ContinualAssumption):
             return self.dataset
 
         else:
-            raise NotImplementedError
+            raise NotImplementedError(self.dataset)
 
     @property
     def observation_space(self) -> ObservationSpace[Observations]:

--- a/sequoia/settings/sl/continual/setting.py
+++ b/sequoia/settings/sl/continual/setting.py
@@ -74,7 +74,27 @@ logger = get_logger(__file__)
 
 EnvironmentType = TypeVar("EnvironmentType", bound=ContinualSLEnvironment)
 
-
+available_datasets = {
+    c.__name__.lower(): c
+    for c in [
+        CIFARFellowship,
+        MNISTFellowship,
+        ImageNet100,
+        ImageNet1000,
+        CIFAR10,
+        CIFAR100,
+        EMNIST,
+        KMNIST,
+        MNIST,
+        QMNIST,
+        FashionMNIST,
+        Synbols,
+    ]
+    # "synbols": Synbols,
+    # "synbols_font": partial(Synbols, task="fonts"),
+}
+if CTRL_INSTALLED:
+    available_datasets.update(dict(zip(CTRL_STREAMS, CTRL_STREAMS)))
 
 
 @dataclass
@@ -112,25 +132,7 @@ class ContinualSLSetting(SLSetting, ContinualAssumption):
     # Class variable holding a dict of the names and types of all available
     # datasets.
     # TODO: Issue #43: Support other datasets than just classification
-    available_datasets: ClassVar[Dict[str, Type[_ContinuumDataset]]] = {
-        c.__name__.lower(): c
-        for c in [
-            CIFARFellowship,
-            MNISTFellowship,
-            ImageNet100,
-            ImageNet1000,
-            CIFAR10,
-            CIFAR100,
-            EMNIST,
-            KMNIST,
-            MNIST,
-            QMNIST,
-            FashionMNIST,
-            Synbols,
-        ]
-        # "synbols": Synbols,
-        # "synbols_font": partial(Synbols, task="fonts"),
-    }
+    available_datasets: ClassVar[Dict[str, Type[_ContinuumDataset]]] = available_datasets
     # A continual dataset to use. (Should be taken from the continuum package).
     dataset: str = choice(available_datasets.keys(), default="mnist")
 

--- a/sequoia/settings/sl/continual/setting_test.py
+++ b/sequoia/settings/sl/continual/setting_test.py
@@ -187,7 +187,7 @@ class TestContinualSLSetting(SettingTests):
         image_shape = (16, 16, 3)
         n_classes = 10
         datasets = [
-            create_image_classification_dataset(image_shape=image_shape, n_classes=2)
+            create_image_classification_dataset(image_shape=image_shape, n_classes=2, y_offset= i * 2)
             for i in range(5)
         ]
         train_datasets = []
@@ -214,7 +214,14 @@ class TestContinualSLSetting(SettingTests):
             train_datasets=train_datasets,
             val_datasets=val_datasets,
             test_datasets=test_datasets,
+            transforms=[],
+            # train_transforms=[],
+            # val_transforms=[],
+            # test_transforms=[]
         )
+        assert setting.train_datasets is train_datasets
+        assert setting.val_datasets is val_datasets
+        assert setting.test_datasets is test_datasets
         assert setting.nb_tasks == len(setting.train_datasets)
         assert setting.observation_space.x.shape == image_shape
         assert setting.reward_space.n == n_classes
@@ -224,6 +231,7 @@ def create_image_classification_dataset(
     image_shape: Tuple[int, ...],
     n_classes: int,
     n_samples_per_class: int = 100,
+    y_offset: int = 0,
 ):
     """Copied and Adapted from
     https://github.com/ContinualAI/avalanche/blob/master/tests/unit_tests_utils.py
@@ -239,8 +247,11 @@ def create_image_classification_dataset(
         n_informative=n_features,
         n_redundant=0,
     )
-    x = torch.from_numpy(dataset[0]).float()
+    x = torch.from_numpy(dataset[0]).reshape([-1, *image_shape]).float()
     y = torch.from_numpy(dataset[1]).long()
+    # y_offset can be used to get [2,3] rather than [0,1] for instance.
+    if y_offset:
+        y += y_offset
     return TensorDataset(x, y)
 
     # train_X, test_X, train_y, test_y = train_test_split(

--- a/sequoia/settings/sl/continual/setting_test.py
+++ b/sequoia/settings/sl/continual/setting_test.py
@@ -227,6 +227,14 @@ class TestContinualSLSetting(SettingTests):
         assert setting.reward_space.n == n_classes
 
 
+    from .envs import CTRL_INSTALLED, CTRL_STREAMS
+    @pytest.mark.skipif(not CTRL_INSTALLED, reason="Need ctrl-benchmark for this test.")
+    @pytest.mark.parametrize("stream", CTRL_STREAMS or [""])
+    def test_ctrl_stream_support(self, stream: str):
+        setting = self.Setting(dataset=stream)
+        assert False, (setting.observation_space, setting.nb_tasks, setting.reward_space)
+    
+
 def create_image_classification_dataset(
     image_shape: Tuple[int, ...],
     n_classes: int,

--- a/sequoia/settings/sl/continual/setting_test.py
+++ b/sequoia/settings/sl/continual/setting_test.py
@@ -1,22 +1,25 @@
-from collections import Counter
-from typing import Any, ClassVar, Dict, Type
 import functools
+from collections import Counter
+from pathlib import Path
+from typing import Any, ClassVar, Dict, Tuple, Type
+
 import gym
 import pytest
+import torch
+from continuum.datasets import MNIST
+from continuum.scenarios import ClassIncremental
+from continuum.tasks import TaskSet, concat
+from sklearn.datasets import make_classification
+from sklearn.model_selection import train_test_split
+from torch.utils.data import TensorDataset, random_split
+
 from sequoia.common.config import Config
 from sequoia.methods import RandomBaselineMethod
 from sequoia.settings import Setting
 from sequoia.settings.base.setting_test import SettingTests
-from pathlib import Path
-
-from .setting import ContinualSLSetting, smooth_task_boundaries_concat, random_subset
-
-
-from continuum.tasks import TaskSet, concat
-from continuum.datasets import MNIST
-from continuum.scenarios import ClassIncremental
-from sequoia.common.config import Config
 from sequoia.settings.sl.continual.setting import shuffle
+
+from .setting import ContinualSLSetting, random_subset, smooth_task_boundaries_concat
 from .wrappers import ShowLabelDistributionWrapper
 
 
@@ -35,7 +38,8 @@ class TestContinualSLSetting(SettingTests):
     # The kwargs to be passed to the Setting when we want to create a 'short' setting.
     # TODO: Transform this into a fixture instead.
     fast_dev_run_kwargs: ClassVar[Dict[str, Any]] = dict(
-        dataset="mnist", batch_size=64,
+        dataset="mnist",
+        batch_size=64,
     )
 
     @pytest.fixture(scope="session")
@@ -83,7 +87,7 @@ class TestContinualSLSetting(SettingTests):
             and not self.Setting.args[0].shared_action_space
         ):
             # NOTE: This `self.Setting` being a partial instead of a Setting class only
-            # happens in the tests for the SettingProxy. 
+            # happens in the tests for the SettingProxy.
             kwargs.update(shared_action_space=True)
         elif not self.Setting.shared_action_space:
             kwargs.update(shared_action_space=True)
@@ -150,8 +154,9 @@ class TestContinualSLSetting(SettingTests):
         setting = self.Setting(dataset="mnist", config=config)
         figures_dir = Path("temp")
 
-        import matplotlib.pyplot as plt
         from functools import partial
+
+        import matplotlib.pyplot as plt
 
         # fig, axes = plt.subplots(2, 3)
         name_to_env_fn = {
@@ -178,6 +183,73 @@ class TestContinualSLSetting(SettingTests):
         # plt.waitforbuttonpress(10)
         # plt.show()
 
+    def test_passing_datasets_to_setting(self, config: Config):
+        image_shape = (16, 16, 3)
+        n_classes = 10
+        datasets = [
+            create_image_classification_dataset(image_shape=image_shape, n_classes=2)
+            for i in range(5)
+        ]
+        train_datasets = []
+        val_datasets = []
+        test_datasets = []
+        for dataset in datasets:
+            n = len(dataset)
+            n_train_val = int(n * 0.8)
+            n_test = n - n_train_val
+            n_train = int(n_train_val * 0.8)
+            n_valid = n_train_val - n_train
+            train_val_dataset, test_dataset = random_split(
+                dataset, [n_train_val, n_test]
+            )
+            train_dataset, val_dataset = random_split(
+                train_val_dataset, [n_train, n_valid]
+            )
+
+            train_datasets.append(train_dataset)
+            val_datasets.append(val_dataset)
+            test_datasets.append(test_dataset)
+
+        setting = self.Setting(
+            train_datasets=train_datasets,
+            val_datasets=val_datasets,
+            test_datasets=test_datasets,
+        )
+        assert setting.nb_tasks == len(setting.train_datasets)
+        assert setting.observation_space.x.shape == image_shape
+        assert setting.reward_space.n == n_classes
+
+
+def create_image_classification_dataset(
+    image_shape: Tuple[int, ...],
+    n_classes: int,
+    n_samples_per_class: int = 100,
+):
+    """Copied and Adapted from
+    https://github.com/ContinualAI/avalanche/blob/master/tests/unit_tests_utils.py
+    """
+    # n_classes = 10
+    # image_shape = (16, 16, 3)
+    # n_samples_per_class = 100
+    n_features = np.prod(image_shape)
+    dataset = make_classification(
+        n_samples=n_classes * n_samples_per_class,
+        n_classes=n_classes,
+        n_features=n_features,
+        n_informative=n_features,
+        n_redundant=0,
+    )
+    x = torch.from_numpy(dataset[0]).float()
+    y = torch.from_numpy(dataset[1]).long()
+    return TensorDataset(x, y)
+
+    # train_X, test_X, train_y, test_y = train_test_split(
+    #     X, y, train_size=0.6, shuffle=True, stratify=y)
+
+    # train_dataset = TensorDataset(train_X, train_y)
+    # test_dataset = TensorDataset(test_X, test_y)
+    # return my_nc_benchmark
+
 
 from typing import List, Tuple
 
@@ -195,7 +267,10 @@ def test_concat_smooth_boundaries(config: Config):
     from continuum.tasks import split_train_val
 
     dataset = MNIST(config.data_dir, download=True, train=True)
-    scenario = ClassIncremental(dataset, increment=2,)
+    scenario = ClassIncremental(
+        dataset,
+        increment=2,
+    )
 
     print(f"Number of classes: {scenario.nb_classes}.")
     print(f"Number of tasks: {scenario.nb_tasks}.")

--- a/sequoia/settings/sl/incremental/setting_test.py
+++ b/sequoia/settings/sl/incremental/setting_test.py
@@ -100,21 +100,15 @@ class TestIncrementalSLSetting(DiscreteTaskAgnosticSLSettingTests):
             assert x in observation_space, (x.min(), x.max(), observation_space)
             assert y in reward_space
 
-
-@pytest.mark.parametrize("dataset_name", ["mnist"])
-def test_task_label_space(dataset_name: str):
-    # dataset = ClassIncrementalSetting.available_datasets[dataset_name]
-    nb_tasks = 2
-    setting = ClassIncrementalSetting(dataset=dataset_name, nb_tasks=nb_tasks,)
-    task_label_space: Space = setting.observation_space.task_labels
-    # TODO: Should the task label space be Sparse[Discrete]? or Discrete?
-    assert task_label_space == Discrete(nb_tasks)
-    assert setting.action_space == Discrete(setting.action_space.n)
-
-    nb_tasks = 5
-    setting.nb_tasks = nb_tasks
-    assert setting.observation_space.task_labels == Discrete(nb_tasks)
-    assert setting.action_space == Discrete(setting.action_space.n)
+    @pytest.mark.parametrize("dataset_name", ["mnist"])
+    @pytest.mark.parametrize("nb_tasks", [2, 5])
+    def test_task_label_space(self, dataset_name: str, nb_tasks: int):
+        # dataset = ClassIncrementalSetting.available_datasets[dataset_name]
+        nb_tasks = 2
+        setting = ClassIncrementalSetting(dataset=dataset_name, nb_tasks=nb_tasks,)
+        task_label_space: Space = setting.observation_space.task_labels
+        # TODO: Should the task label space be Sparse[Discrete]? or Discrete?
+        assert task_label_space == Discrete(nb_tasks)
 
     @pytest.mark.parametrize("dataset_name", ["mnist"])
     def test_setting_obs_space_changes_when_transforms_change(self, dataset_name: str):

--- a/sequoia/settings/sl/incremental/setting_test.py
+++ b/sequoia/settings/sl/incremental/setting_test.py
@@ -12,6 +12,7 @@ from sequoia.conftest import skip_param, xfail_param
 from sequoia.settings.assumptions.incremental_test import OtherDummyMethod
 from sequoia.settings.base import Setting
 from sequoia.settings.base.setting_test import SettingTests
+from sequoia.settings.sl.continual.envs import get_action_space
 
 from ..discrete.setting_test import (
     TestDiscreteTaskAgnosticSLSetting as DiscreteTaskAgnosticSLSettingTests,
@@ -36,7 +37,10 @@ class TestIncrementalSLSetting(DiscreteTaskAgnosticSLSettingTests):
         # TODO: This test so far needs the 'N' to be the number of classes in total,
         # not the number of classes per task.
         # num_classes = setting.action_space.n  # <-- Should be using this instead.
-        num_classes = setting.base_action_spaces[setting.dataset].n
+        if setting._using_custom_envs_foreach_task:
+            num_classes = get_action_space(setting.train_datasets[0]).n
+        else:
+            num_classes = get_action_space(setting.dataset).n
 
         average_accuracy = results.objective
         # Calculate the expected 'average' chance accuracy.


### PR DESCRIPTION
- Allow passing datasets for each task the the Settings in SL (a bit like what is already supported in RL)
- Add the `"s_plus", "s_minus", "s_in", "s_out", "s_pl", "s_long"` streams from the [CTrlBenchmark repo](https://github.com/facebookresearch/CTrLBenchmark)  as datasets. They can be used in any SL Setting.