### PR TITLE
Pass a seed to env.seed for MetaWorld envs

### DIFF
--- a/sequoia/common/gym_wrappers/multi_task_environment.py
+++ b/sequoia/common/gym_wrappers/multi_task_environment.py
@@ -533,6 +533,7 @@ class MultiTaskEnvironment(MayCloseEarly):
         self.np_random = np.random.default_rng(seed)
         self.action_space.seed(seed)
         self.observation_space.seed(seed)
+        # NOTE: Mujoco envs require a seed, so passing `seed=None` here will cause an error.
         return self.env.seed(seed)
 
     def task_dict(self, task_array: np.ndarray) -> Dict[str, float]:

--- a/sequoia/settings/rl/incremental/setting.py
+++ b/sequoia/settings/rl/incremental/setting.py
@@ -1092,6 +1092,7 @@ def make_metaworld_env(env_class: Type[MetaWorldEnv], tasks: List["Task"]) -> Me
         new_random_task_on_reset=True,
         add_task_dict_to_info=False,
         add_task_id_to_obs=False,
+        seed=42,
     )
     return env
 


### PR DESCRIPTION
This would cause an error when running the CW10 benchmark, for example, since the `MultiTaskEnvironment` constructor calls `self.seed(seed)`, which calls `self.env.seed(seed)`. In the case of Mujoco environments created by the MetaWorld benchmark, this isn't good, because there's an `assert seed is not None` in their source code.

This was probably caused by the metaworld / mujoco-py dependency not being pinned properly enough. If I find the time, I'll look into this some more.

NOTE: This slightly changes the seeding of the Metaworld environments, which might change the results of some experiments.
